### PR TITLE
fix(core): fix svacer issues in virt-launcher and virt-handler

### DIFF
--- a/pkg/liveupdate/memory/memory.go
+++ b/pkg/liveupdate/memory/memory.go
@@ -108,6 +108,10 @@ func ValidateLiveUpdateMemory(vmSpec *v1.VirtualMachineInstanceSpec, maxGuest *r
 }
 
 func BuildMemoryDevice(vmi *v1.VirtualMachineInstance) (*api.MemoryDevice, error) {
+	if vmi == nil {
+		return nil, fmt.Errorf("VMI is nil")
+	}
+
 	domain := vmi.Spec.Domain
 
 	pluggableMemory := domain.Memory.MaxGuest.DeepCopy()

--- a/pkg/monitoring/metrics/common/client/rt_wrapper.go
+++ b/pkg/monitoring/metrics/common/client/rt_wrapper.go
@@ -64,7 +64,7 @@ func parseURLResourceOperation(request *http.Request) (resource string, verb str
 	resource = ""
 	verb = ""
 
-	if request.URL.Path == "" || method == "" {
+	if request.URL == nil || request.URL.Path == "" || method == "" {
 		return
 	}
 

--- a/pkg/virt-handler/container-disk/mount.go
+++ b/pkg/virt-handler/container-disk/mount.go
@@ -530,7 +530,7 @@ func (m *mounter) mountKernelArtifacts(vmi *v1.VirtualMachineInstance, verify bo
 			}
 		}
 
-		if kernelArtifacts.initrd != nil {
+		if kernelArtifacts.initrd != nil && targetInitrdPath != nil {
 			out, err := virt_chroot.MountChroot(kernelArtifacts.initrd, targetInitrdPath, true).CombinedOutput()
 			if err != nil {
 				return fmt.Errorf("failed to bindmount %v: %v : %v", kernelBootName, string(out), err)

--- a/pkg/virt-handler/container-disk/mount.go
+++ b/pkg/virt-handler/container-disk/mount.go
@@ -530,7 +530,7 @@ func (m *mounter) mountKernelArtifacts(vmi *v1.VirtualMachineInstance, verify bo
 			}
 		}
 
-		if kernelArtifacts.initrd != nil && targetInitrdPath != nil {
+		if kernelArtifacts.initrd != nil {
 			out, err := virt_chroot.MountChroot(kernelArtifacts.initrd, targetInitrdPath, true).CombinedOutput()
 			if err != nil {
 				return fmt.Errorf("failed to bindmount %v: %v : %v", kernelBootName, string(out), err)

--- a/pkg/virt-handler/device-manager/common.go
+++ b/pkg/virt-handler/device-manager/common.go
@@ -188,6 +188,10 @@ func (h *DeviceUtilsHandler) ReadMDEVAvailableInstances(mdevType string, parentI
 		return 0, err
 	}
 
+	if len(lines) == 0 {
+		return 0, fmt.Errorf("no data found in %s", path)
+	}
+
 	i, err := strconv.Atoi(string(lines[0]))
 	if err != nil {
 		return 0, err

--- a/pkg/virt-handler/virt-chroot/virt-chroot.go
+++ b/pkg/virt-handler/virt-chroot/virt-chroot.go
@@ -48,9 +48,6 @@ func GetChrootMountNamespace() string {
 }
 
 func MountChroot(sourcePath, targetPath *safepath.Path, ro bool) *exec.Cmd {
-	if targetPath == nil {
-		return nil
-	}
 	return UnsafeMountChroot(trimProcPrefix(sourcePath), trimProcPrefix(targetPath), ro)
 }
 

--- a/pkg/virt-handler/virt-chroot/virt-chroot.go
+++ b/pkg/virt-handler/virt-chroot/virt-chroot.go
@@ -48,6 +48,9 @@ func GetChrootMountNamespace() string {
 }
 
 func MountChroot(sourcePath, targetPath *safepath.Path, ro bool) *exec.Cmd {
+	if targetPath == nil {
+		return nil
+	}
 	return UnsafeMountChroot(trimProcPrefix(sourcePath), trimProcPrefix(targetPath), ro)
 }
 

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -722,6 +722,9 @@ func (d *VirtualMachineController) migrationSourceUpdateVMIStatus(origVMI *v1.Vi
 	if migrationHost == "" {
 		// migrated to unknown host.
 		vmi.Status.Phase = v1.Failed
+		if vmi.Status.MigrationState == nil {
+			vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{}
+		}
 		vmi.Status.MigrationState.Completed = true
 		vmi.Status.MigrationState.Failed = true
 

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -567,7 +567,7 @@ func (d *VirtualMachineController) hasTargetDetectedReadyDomain(vmi *v1.VirtualM
 	}
 
 	if vmi.Status.MigrationState == nil {
-		return false, 0
+		vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{}
 	}
 
 	nowUnix := time.Now().UTC().Unix()

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -566,6 +566,10 @@ func (d *VirtualMachineController) hasTargetDetectedReadyDomain(vmi *v1.VirtualM
 		return true, 0
 	}
 
+	if vmi.Status.MigrationState == nil {
+		return false, 0
+	}
+
 	nowUnix := time.Now().UTC().Unix()
 	migrationEndUnix := vmi.Status.MigrationState.EndTimestamp.Time.UTC().Unix()
 

--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -444,7 +444,7 @@ func (n *Notifier) StartDomainNotifier(
 				guestOsInfo = agentUpdate.DomainInfo.OSInfo
 				fsFreezeStatus = agentUpdate.DomainInfo.FSFreezeStatus
 				if domainCache != nil {
-					cache := *domainCache.DeepCopy()
+					cache := *domainCache
 					eventCallback(domainConn, &cache, libvirtEvent{}, n, deleteNotificationSent,
 						interfaceStatuses, guestOsInfo, vmi, fsFreezeStatus, metadataCache)
 				}

--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -443,9 +443,11 @@ func (n *Notifier) StartDomainNotifier(
 				interfaceStatuses = agentUpdate.DomainInfo.Interfaces
 				guestOsInfo = agentUpdate.DomainInfo.OSInfo
 				fsFreezeStatus = agentUpdate.DomainInfo.FSFreezeStatus
-
-				eventCallback(domainConn, domainCache, libvirtEvent{}, n, deleteNotificationSent,
-					interfaceStatuses, guestOsInfo, vmi, fsFreezeStatus, metadataCache)
+				if domainCache != nil {
+					cache := *domainCache.DeepCopy()
+					eventCallback(domainConn, &cache, libvirtEvent{}, n, deleteNotificationSent,
+						interfaceStatuses, guestOsInfo, vmi, fsFreezeStatus, metadataCache)
+				}
 			case <-reconnectChan:
 				n.SendDomainEvent(newWatchEventError(fmt.Errorf("Libvirt reconnect, domain %s", domainName)))
 

--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -1299,6 +1299,10 @@ func (dl *DomainList) GetListMeta() meta.List {
 // VMINamespaceKeyFunc constructs the domain name with a namespace prefix i.g.
 // namespace_name.
 func VMINamespaceKeyFunc(vmi *v1.VirtualMachineInstance) string {
+	if vmi == nil {
+		return ""
+	}
+
 	domName := fmt.Sprintf("%s_%s", vmi.Namespace, vmi.Name)
 	return domName
 }

--- a/pkg/virt-launcher/virtwrap/converter/vcpu/vcpu.go
+++ b/pkg/virt-launcher/virtwrap/converter/vcpu/vcpu.go
@@ -291,6 +291,10 @@ func (p *cpuPool) fitThread() (thread *uint32) {
 }
 
 func GetCPUTopology(vmi *v12.VirtualMachineInstance) *api.CPUTopology {
+	if vmi == nil {
+		return nil
+	}
+
 	cores := uint32(1)
 	threads := uint32(1)
 	sockets := uint32(1)

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1173,6 +1173,10 @@ func isSerialConsoleLogEnabled(clusterSerialConsoleLogDisabled bool, vmi *v1.Vir
 }
 
 func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, allowEmulation bool, options *cmdv1.VirtualMachineOptions) (*api.DomainSpec, error) {
+	if vmi == nil {
+		return nil, fmt.Errorf("VMI is nil")
+	}
+
 	l.domainModifyLock.Lock()
 	defer l.domainModifyLock.Unlock()
 

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -648,6 +648,10 @@ func (l *LibvirtDomainManager) HotplugHostDevices(vmi *v1.VirtualMachineInstance
 }
 
 func (l *LibvirtDomainManager) hotPlugHostDevices(vmi *v1.VirtualMachineInstance) error {
+	if vmi == nil {
+		return fmt.Errorf("VMI is nil")
+	}
+
 	l.domainModifyLock.Lock()
 	defer l.domainModifyLock.Unlock()
 


### PR DESCRIPTION
Fixed issues in virt-launcher:
- After having been compared to a nil value at rt_wrapper.go:45, pointer 'request.URL' is passed in call to function 'kubevirt.io/kubevirt/pkg/monitoring/metrics/common/client.parseURLResourceOperation' at rt_wrapper.go:49, where it is dereferenced at rt_wrapper.go:67.
- After having been compared to a nil value at client.go:455, pointer 'domainCache' is passed as 2nd parameter in call to function 'kubevirt.io/kubevirt/pkg/virt-launcher/notify-client.eventCallback' at client.go:447, where it is dereferenced at client.go:247.
- After having been compared to a nil value at manager.go:341, pointer 'vmi' is passed as 1st parameter in call to function 'kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api.VMINamespaceKeyFunc' at manager.go:347, where it is dereferenced at schema.go:1302.
- After having been compared to a nil value at manager.go:516, pointer 'vmi' is passed as 1st parameter in call to function 'kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api.VMINamespaceKeyFunc' at manager.go:522, where it is dereferenced at schema.go:1302.
- After having been compared to a nil value at manager.go:633, pointer 'vmi' is passed as 1st parameter in call to function 'kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap.LibvirtDomainManager.hotPlugHostDevices' at manager.go:636, where it is dereferenced at manager.go:656.
- After having been compared to a nil value at manager.go:1176, pointer 'vmi' is passed as 1st parameter in call to function 'kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter.Convert_v1_VirtualMachineInstance_To_api_Domain' at manager.go:1190, where it is dereferenced at converter.go:1362.
- After having been compared to a nil value at manager.go:341, pointer 'vmi' is passed as 1st parameter in call to function 'kubevirt.io/kubevirt/pkg/liveupdate/memory.BuildMemoryDevice' at manager.go:354, where it is dereferenced at memory.go:111.
- After having been compared to a nil value at manager.go:516, pointer 'vmi' is passed as 1st parameter in call to function 'kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/vcpu.GetCPUTopology' at manager.go:532, where it is dereferenced at vcpu.go:297.
---
Fixed issues in virt-handler:
- After having been compared to a nil value at rt_wrapper.go:45, pointer 'request.URL' is passed in call to function 'kubevirt.io/kubevirt/pkg/monitoring/metrics/common/client.parseURLResourceOperation' at rt_wrapper.go:49, where it is dereferenced at rt_wrapper.go:67.
- After having been assigned to a nil value at mount.go:487, pointer 'targetInitrdPath' is passed as 2nd parameter in call to function 'kubevirt.io/kubevirt/pkg/virt-handler/virt-chroot.MountChroot' at mount.go:534, where it is dereferenced at virt-chroot.go:51.
- After having been compared to a nil value at vm.go:562, pointer 'vmi.Status->MigrationState' is dereferenced at vm.go:570.
- After having been compared to a nil value at vm.go:711, pointer 'vmi.Status->MigrationState' is dereferenced at vm.go:725.
- After having been assigned to a nil value at common.go:183, pointer 'lines[0]' is dereferenced at common.go:191.

