### PR TITLE
feat: support hotplug of PVCs with filesystem volume mode

### DIFF
--- a/pkg/host-disk/creator.go
+++ b/pkg/host-disk/creator.go
@@ -1,0 +1,89 @@
+package hostdisk
+
+import (
+	"fmt"
+
+	"k8s.io/client-go/tools/record"
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/log"
+
+	ephemeraldiskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
+)
+
+func newDiskImgCreator(recorder record.EventRecorder, lessPVCSpaceToleration int, minimumPVCReserveBytes uint64) diskImgCreator {
+	return diskImgCreator{
+		dirBytesAvailableFunc:  dirBytesAvailable,
+		recorder:               recorder,
+		lessPVCSpaceToleration: lessPVCSpaceToleration,
+		minimumPVCReserveBytes: minimumPVCReserveBytes,
+	}
+}
+
+type diskImgCreator struct {
+	dirBytesAvailableFunc  func(path string, reserve uint64) (uint64, error)
+	recorder               record.EventRecorder
+	lessPVCSpaceToleration int
+	minimumPVCReserveBytes uint64
+}
+
+func (c diskImgCreator) CreateDiskAndSetOwnership(vmi *v1.VirtualMachineInstance, diskDir, diskPath, volumeName string, requestedSize int64) error {
+	fileExists, err := ephemeraldiskutils.FileExists(diskPath)
+	if err != nil {
+		return err
+	}
+	if !fileExists {
+		if err := c.handleRequestedSizeAndCreateQcow2(vmi, diskDir, diskPath, volumeName, requestedSize); err != nil {
+			return err
+		}
+	}
+	// Change file ownership to the qemu user.
+	if err := ephemeraldiskutils.DefaultOwnershipManager.UnsafeSetFileOwnership(diskPath); err != nil {
+		log.Log.Reason(err).Errorf("Couldn't set Ownership on %s: %v", diskPath, err)
+		return err
+	}
+	return nil
+}
+
+func (c diskImgCreator) handleRequestedSizeAndCreateQcow2(vmi *v1.VirtualMachineInstance, diskDir, diskPath, volumeName string, requestedSize int64) error {
+	size, err := c.dirBytesAvailableFunc(diskDir, c.minimumPVCReserveBytes)
+	availableSize := int64(size)
+	if err != nil {
+		return err
+	}
+	if requestedSize > availableSize {
+		requestedSize, err = c.shrinkRequestedSize(vmi, requestedSize, availableSize, volumeName)
+		if err != nil {
+			return err
+		}
+	}
+	err = createQcow2(diskPath, requestedSize)
+	if err != nil {
+		log.Log.Reason(err).Errorf("Couldn't create a qcow2 file for disk path: %s, error: %v", diskPath, err)
+		return err
+	}
+	return nil
+}
+
+func (c diskImgCreator) shrinkRequestedSize(vmi *v1.VirtualMachineInstance, requestedSize int64, availableSize int64, volumeName string) (int64, error) {
+	// Some storage provisioners provide less space than requested, due to filesystem overhead etc.
+	// We tolerate some difference in requested and available capacity up to some degree.
+	// This can be configured with the "pvc-tolerate-less-space-up-to-percent" parameter in the kubevirt-config ConfigMap.
+	// It is provided as argument to virt-launcher.
+	toleratedSize := requestedSize * (100 - int64(c.lessPVCSpaceToleration)) / 100
+	if toleratedSize > availableSize {
+		return 0, fmt.Errorf("unable to create image on volume %s, not enough space, demanded size %d B is bigger than available space %d B, also after taking %v %% toleration into account",
+			volumeName, uint64(requestedSize), availableSize, c.lessPVCSpaceToleration)
+	}
+	requestedSizeMsg := fmt.Sprintf("%v B", requestedSize)
+	if requestedSize > 1*1024*1024 {
+		requestedSizeMsg = fmt.Sprintf("%v MiB", requestedSize/(1024*1024))
+	}
+	availableSizeMsg := fmt.Sprintf("%v B", availableSize)
+	if availableSize > 1*1024*1024 {
+		availableSizeMsg = fmt.Sprintf("%v MiB", availableSize/(1024*1024))
+	}
+	msg := fmt.Sprintf("PV size too small: expected %s, found %s. Using it anyway, it is within %v %% toleration", requestedSizeMsg, availableSizeMsg, c.lessPVCSpaceToleration)
+	log.Log.Info(msg)
+	c.recorder.Event(vmi, EventTypeToleratedSmallPV, EventReasonToleratedSmallPV, msg)
+	return availableSize, nil
+}

--- a/pkg/host-disk/disk.go
+++ b/pkg/host-disk/disk.go
@@ -48,7 +48,7 @@ func (c PVCDiskImgCreator) Create(vmi *v1.VirtualMachineInstance, volumeName, di
 		return fmt.Errorf("unable to determine capacity from PVC that provides no storage capacity or requests")
 	}
 	var requestedSize int64
-	if hasRequests && (capacity.Value() > requested.Value() || !hasCapacity) {
+	if hasRequests && (!hasCapacity || capacity.Value() > requested.Value()) {
 		requestedSize = util.AlignImageSizeTo1MiB(requested.Value(), log.Log)
 	} else {
 		requestedSize = util.AlignImageSizeTo1MiB(capacity.Value(), log.Log)

--- a/pkg/host-disk/disk.go
+++ b/pkg/host-disk/disk.go
@@ -1,0 +1,63 @@
+package hostdisk
+
+import (
+	"fmt"
+	"path/filepath"
+
+	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/log"
+
+	"kubevirt.io/kubevirt/pkg/util"
+)
+
+type PVCDiskImgCreator struct {
+	diskImgCreator diskImgCreator
+}
+
+func NewPVCDiskImgCreator(recorder record.EventRecorder, lessPVCSpaceToleration int, minimumPVCReserveBytes uint64) PVCDiskImgCreator {
+	return PVCDiskImgCreator{
+		diskImgCreator: newDiskImgCreator(recorder, lessPVCSpaceToleration, minimumPVCReserveBytes),
+	}
+}
+
+func getPVCInfo(vmi *v1.VirtualMachineInstance, volumeName string) (*v1.PersistentVolumeClaimInfo, error) {
+	for _, volumeStatus := range vmi.Status.VolumeStatus {
+		if volumeStatus.Name == volumeName {
+			if volumeStatus.PersistentVolumeClaimInfo.VolumeMode == nil || *volumeStatus.PersistentVolumeClaimInfo.VolumeMode != k8sv1.PersistentVolumeFilesystem {
+				return nil, fmt.Errorf("volume %s is not in filesystem mode", volumeName)
+			}
+			return volumeStatus.PersistentVolumeClaimInfo, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no disk found")
+}
+
+func (c PVCDiskImgCreator) Create(vmi *v1.VirtualMachineInstance, volumeName, diskPath string) error {
+	pvcInfo, err := getPVCInfo(vmi, volumeName)
+	if err != nil {
+		return err
+	}
+
+	capacity, hasCapacity := pvcInfo.Capacity[k8sv1.ResourceStorage]
+	requested, hasRequests := pvcInfo.Requests[k8sv1.ResourceStorage]
+
+	if !hasCapacity && !hasRequests {
+		return fmt.Errorf("unable to determine capacity from PVC that provides no storage capacity or requests")
+	}
+	var requestedSize int64
+	if hasRequests && (capacity.Value() > requested.Value() || !hasCapacity) {
+		requestedSize = util.AlignImageSizeTo1MiB(requested.Value(), log.Log)
+	} else {
+		requestedSize = util.AlignImageSizeTo1MiB(capacity.Value(), log.Log)
+	}
+
+	if requestedSize == 0 {
+		return fmt.Errorf("the size for volume %s is too low, must be at least 1MiB", pvcInfo.ClaimName)
+	}
+
+	diskDir := filepath.Dir(diskPath)
+	return c.diskImgCreator.CreateDiskAndSetOwnership(vmi, diskDir, diskPath, pvcInfo.ClaimName, requestedSize)
+}

--- a/pkg/virt-handler/container-disk/hotplug.go
+++ b/pkg/virt-handler/container-disk/hotplug.go
@@ -484,8 +484,11 @@ func (m *hotplugMounter) Umount(vmi *v1.VirtualMachineInstance) error {
 		}
 		newEntries = append(newEntries, entry)
 	}
-	record.MountTargetEntries = newEntries
-	return m.setMountTargetRecord(vmi, record)
+	if record != nil {
+		record.MountTargetEntries = newEntries
+		return m.setMountTargetRecord(vmi, record)
+	}
+	return nil
 }
 
 func extractNameFromSocket(socketFile string) (string, error) {

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -241,7 +241,6 @@ func NewController(
 		migrationProxy:              migrationProxy,
 		podIsolationDetector:        podIsolationDetector,
 		containerDiskMounter:        container_disk.NewMounter(podIsolationDetector, filepath.Join(virtPrivateDir, "container-disk-mount-state"), clusterConfig),
-		hotplugVolumeMounter:        hotplug_volume.NewVolumeMounter(filepath.Join(virtPrivateDir, "hotplug-volume-mount-state"), kubeletPodsDir),
 		clusterConfig:               clusterConfig,
 		virtLauncherFSRunDirPattern: "/proc/%d/root/var/run",
 		capabilities:                capabilities,
@@ -258,6 +257,11 @@ func NewController(
 		),
 		nam: migrations.NewNetworkAccessibilityManager(clientset),
 	}
+
+	c.hotplugVolumeMounter = hotplug_volume.NewVolumeMounterWithCreator(filepath.Join(virtPrivateDir, "hotplug-volume-mount-state"), kubeletPodsDir,
+		func() hostdisk.PVCDiskImgCreator {
+			return hostdisk.NewPVCDiskImgCreator(recorder, c.clusterConfig.GetLessPVCSpaceToleration(), c.clusterConfig.GetMinimumReservePVCBytes())
+		})
 
 	_, err := vmiSourceInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.addFunc,
@@ -2971,7 +2975,7 @@ func (d *VirtualMachineController) vmUpdateHelperMigrationTarget(origVMI *v1.Vir
 	minimumPVCReserveBytes := d.clusterConfig.GetMinimumReservePVCBytes()
 
 	// initialize disks images for empty PVC
-	hostDiskCreator := hostdisk.NewHostDiskCreator(d.recorder, lessPVCSpaceToleration, minimumPVCReserveBytes, virtLauncherRootMount)
+	hostDiskCreator := hostdisk.NewHostDiskImgCreator(d.recorder, lessPVCSpaceToleration, minimumPVCReserveBytes, virtLauncherRootMount)
 	err = hostDiskCreator.Create(vmi)
 	if err != nil {
 		return fmt.Errorf("preparing host-disks failed: %v", err)
@@ -3199,7 +3203,7 @@ func (d *VirtualMachineController) vmUpdateHelperDefault(origVMI *v1.VirtualMach
 		minimumPVCReserveBytes := d.clusterConfig.GetMinimumReservePVCBytes()
 
 		// initialize disks images for empty PVC
-		hostDiskCreator := hostdisk.NewHostDiskCreator(d.recorder, lessPVCSpaceToleration, minimumPVCReserveBytes, virtLauncherRootMount)
+		hostDiskCreator := hostdisk.NewHostDiskImgCreator(d.recorder, lessPVCSpaceToleration, minimumPVCReserveBytes, virtLauncherRootMount)
 		err = hostDiskCreator.Create(vmi)
 		if err != nil {
 			return fmt.Errorf("preparing host-disks failed: %v", err)

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1276,11 +1276,17 @@ func (l *LibvirtDomainManager) syncDiskHotplug(
 	}
 	// Look up all the disks to attach
 	for _, attachDisk := range getAttachedDisks(spec.Devices.Disks, domain.Spec.Devices.Disks) {
-		allowAttach, err := checkIfDiskReadyToUse(getSourceFile(attachDisk))
+		sourceFile := getSourceFile(attachDisk)
+		allowAttach, err := checkIfDiskReadyToUse(sourceFile)
 		if err != nil {
 			return err
 		}
 		if !allowAttach {
+			diskName := ""
+			if attachDisk.Alias != nil {
+				diskName = attachDisk.Alias.GetName()
+			}
+			logger.Reason(fmt.Errorf("disk %s is not ready to use", diskName)).Errorf("Skipping disk %s. SourceFile: %q", diskName, sourceFile)
 			continue
 		}
 		logger.V(1).Infof("Attaching disk %s, target %s", attachDisk.Alias.GetName(), attachDisk.Target.Device)
@@ -1445,6 +1451,7 @@ func checkIfDiskReadyToUseFunc(filename string) (bool, error) {
 	// Before attempting to attach, ensure we can open the file
 	file, err := os.OpenFile(filename, os.O_RDWR, 0600)
 	if err != nil {
+		log.DefaultLogger().V(1).Infof("Unable to open file: %v", err)
 		return false, nil
 	}
 	if err := file.Close(); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This PR adds support for hot-plugging PVCs in `Filesystem` mode in KubeVirt. If the expected disk image file (e.g., `disk.img`) is missing, KubeVirt will now create it automatically before attaching the volume to a running Virtual Machine.

### Before this PR:

When hot-plugging a PVC in `Filesystem` mode, KubeVirt expected the disk image file (like `disk.img`) to already exist on the filesystem. If the file was not present, the operation would fail at runtime when the file was not found, causing the hot-plug to fail unexpectedly.

### After this PR:

KubeVirt now checks for the presence of the required disk image file before proceeding with the hot-plug operation. If the file is missing, it will be created automatically, allowing the hot-plug to succeed as expected.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

