### PR TITLE
feat(core): read-only containers

### DIFF
--- a/pkg/container-disk/container-disk.go
+++ b/pkg/container-disk/container-disk.go
@@ -31,6 +31,7 @@ import (
 	kubev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
 
 	"kubevirt.io/kubevirt/pkg/safepath"
 
@@ -386,6 +387,7 @@ func generateContainerFromVolume(vmi *v1.VirtualMachineInstance, config *virtcon
 		SecurityContext: &kubev1.SecurityContext{
 			RunAsUser:                &userId,
 			RunAsNonRoot:             &nonRoot,
+			ReadOnlyRootFilesystem:   pointer.Bool(true),
 			AllowPrivilegeEscalation: &noPrivilegeEscalation,
 			Capabilities: &kubev1.Capabilities{
 				Drop: []kubev1.Capability{"ALL"},

--- a/pkg/virt-controller/services/rendercontainer.go
+++ b/pkg/virt-controller/services/rendercontainer.go
@@ -184,10 +184,11 @@ func xdgEnvironmentVariables() []k8sv1.EnvVar {
 func securityContext(userId int64, privileged bool, requiredCapabilities *k8sv1.Capabilities) *k8sv1.SecurityContext {
 	isNonRoot := userId != 0
 	context := &k8sv1.SecurityContext{
-		RunAsUser:    &userId,
-		RunAsNonRoot: &isNonRoot,
-		Privileged:   &privileged,
-		Capabilities: requiredCapabilities,
+		RunAsUser:              &userId,
+		RunAsNonRoot:           &isNonRoot,
+		Privileged:             &privileged,
+		Capabilities:           requiredCapabilities,
+		ReadOnlyRootFilesystem: pointer.Bool(true),
 	}
 
 	if isNonRoot {

--- a/pkg/virt-controller/services/serialconsolelog.go
+++ b/pkg/virt-controller/services/serialconsolelog.go
@@ -38,6 +38,7 @@ func generateSerialConsoleLogContainer(vmi *v1.VirtualMachineInstance, image str
 				RunAsUser:                pointer.Int64(util.NonRootUID),
 				RunAsNonRoot:             pointer.Bool(true),
 				AllowPrivilegeEscalation: pointer.Bool(false),
+				ReadOnlyRootFilesystem:   pointer.Bool(true),
 				Capabilities: &k8sv1.Capabilities{
 					Drop: []k8sv1.Capability{"ALL"},
 				},

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -894,6 +894,7 @@ func (t *templateService) containerForHotplugContainerDisk(ctrName, volName stri
 		Resources: hotplugContainerResourceRequirementsForVMI(vmi, t.clusterConfig),
 		SecurityContext: &k8sv1.SecurityContext{
 			AllowPrivilegeEscalation: pointer.Bool(false),
+			ReadOnlyRootFilesystem:   pointer.Bool(true),
 			RunAsNonRoot:             pointer.Bool(true),
 			RunAsUser:                &runUser,
 			SeccompProfile: &k8sv1.SeccompProfile{
@@ -950,6 +951,7 @@ func (t *templateService) RenderHotplugAttachmentPodTemplate(volumes []*v1.Volum
 					Resources: hotplugContainerResourceRequirementsForVMI(vmi, t.clusterConfig),
 					SecurityContext: &k8sv1.SecurityContext{
 						AllowPrivilegeEscalation: pointer.Bool(false),
+						ReadOnlyRootFilesystem:   pointer.Bool(true),
 						RunAsNonRoot:             pointer.Bool(true),
 						RunAsUser:                &runUser,
 						SeccompProfile: &k8sv1.SeccompProfile{
@@ -1123,6 +1125,7 @@ func (t *templateService) RenderHotplugAttachmentTriggerPodTemplate(volume *v1.V
 					Command:   command,
 					Resources: hotplugContainerResourceRequirementsForVMI(vmi, t.clusterConfig),
 					SecurityContext: &k8sv1.SecurityContext{
+						ReadOnlyRootFilesystem:   pointer.Bool(true),
 						AllowPrivilegeEscalation: pointer.Bool(false),
 						RunAsNonRoot:             pointer.Bool(true),
 						RunAsUser:                &runUser,
@@ -1233,6 +1236,7 @@ func (t *templateService) RenderExporterManifest(vmExport *exportv1.VirtualMachi
 					},
 					SecurityContext: &k8sv1.SecurityContext{
 						AllowPrivilegeEscalation: pointer.Bool(false),
+						ReadOnlyRootFilesystem:   pointer.Bool(true),
 						Capabilities:             &k8sv1.Capabilities{Drop: []k8sv1.Capability{"ALL"}},
 					},
 					Resources: vmExportContainerResourceRequirements(t.clusterConfig),
@@ -1427,6 +1431,7 @@ func generateContainerSecurityContext(selinuxType string, container *k8sv1.Conta
 	}
 	container.SecurityContext.SELinuxOptions.Type = selinuxType
 	container.SecurityContext.SELinuxOptions.Level = "s0"
+	container.SecurityContext.ReadOnlyRootFilesystem = pointer.Bool(true)
 }
 
 func generatePodAnnotations(vmi *v1.VirtualMachineInstance, config *virtconfig.ClusterConfig) (map[string]string, error) {

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -894,9 +894,9 @@ func (t *templateService) containerForHotplugContainerDisk(ctrName, volName stri
 		Resources: hotplugContainerResourceRequirementsForVMI(vmi, t.clusterConfig),
 		SecurityContext: &k8sv1.SecurityContext{
 			AllowPrivilegeEscalation: pointer.Bool(false),
-			// ReadOnlyRootFilesystem:   pointer.Bool(true),
-			RunAsNonRoot: pointer.Bool(true),
-			RunAsUser:    &runUser,
+			ReadOnlyRootFilesystem:   pointer.Bool(true),
+			RunAsNonRoot:             pointer.Bool(true),
+			RunAsUser:                &runUser,
 			SeccompProfile: &k8sv1.SeccompProfile{
 				Type: k8sv1.SeccompProfileTypeRuntimeDefault,
 			},

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -894,9 +894,9 @@ func (t *templateService) containerForHotplugContainerDisk(ctrName, volName stri
 		Resources: hotplugContainerResourceRequirementsForVMI(vmi, t.clusterConfig),
 		SecurityContext: &k8sv1.SecurityContext{
 			AllowPrivilegeEscalation: pointer.Bool(false),
-			ReadOnlyRootFilesystem:   pointer.Bool(true),
-			RunAsNonRoot:             pointer.Bool(true),
-			RunAsUser:                &runUser,
+			// ReadOnlyRootFilesystem:   pointer.Bool(true),
+			RunAsNonRoot: pointer.Bool(true),
+			RunAsUser:    &runUser,
 			SeccompProfile: &k8sv1.SeccompProfile{
 				Type: k8sv1.SeccompProfileTypeRuntimeDefault,
 			},

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -3938,6 +3938,7 @@ var _ = Describe("Template", func() {
 			runUser := int64(util.NonRootUID)
 			Expect(*pod.Spec.Containers[0].SecurityContext).To(Equal(k8sv1.SecurityContext{
 				AllowPrivilegeEscalation: pointer.Bool(false),
+				ReadOnlyRootFilesystem:   pointer.Bool(true),
 				RunAsNonRoot:             pointer.Bool(true),
 				RunAsUser:                &runUser,
 				SeccompProfile: &k8sv1.SeccompProfile{
@@ -4052,6 +4053,7 @@ var _ = Describe("Template", func() {
 			runUser := int64(util.NonRootUID)
 			Expect(*pod.Spec.Containers[0].SecurityContext).To(Equal(k8sv1.SecurityContext{
 				AllowPrivilegeEscalation: pointer.Bool(false),
+				ReadOnlyRootFilesystem:   pointer.Bool(true),
 				RunAsNonRoot:             pointer.Bool(true),
 				RunAsUser:                &runUser,
 				SeccompProfile: &k8sv1.SeccompProfile{

--- a/pkg/virt-controller/services/virtiofs.go
+++ b/pkg/virt-controller/services/virtiofs.go
@@ -128,6 +128,7 @@ func securityContextVirtioFS(profile securityProfile) *k8sv1.SecurityContext {
 		RunAsGroup:               credential,
 		RunAsNonRoot:             pointer.Bool(isRestricted(profile)),
 		AllowPrivilegeEscalation: pointer.Bool(isPrivileged(profile)),
+		ReadOnlyRootFilesystem:   pointer.Bool(true),
 		Capabilities:             virtiofsCapabilities(profile),
 	}
 }

--- a/pkg/virt-operator/resource/generate/components/daemonsets.go
+++ b/pkg/virt-operator/resource/generate/components/daemonsets.go
@@ -157,6 +157,10 @@ func NewHandlerDaemonSet(namespace, repository, imagePrefix, version, launcherVe
 
 	pod.Volumes = []corev1.Volume{
 		{
+			Name:         "tmp-dir",
+			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+		},
+		{
 			Name:         "var-run",
 			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
 		},
@@ -353,6 +357,10 @@ func NewHandlerDaemonSet(namespace, repository, imagePrefix, version, launcherVe
 	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
 		Name:      "podinfo",
 		MountPath: "/etc/podinfo",
+	})
+	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+		Name:      "tmp-dir",
+		MountPath: "/tmp",
 	})
 	pod.Volumes = append(pod.Volumes, corev1.Volume{
 		Name: "podinfo",

--- a/pkg/virt-operator/resource/generate/components/daemonsets.go
+++ b/pkg/virt-operator/resource/generate/components/daemonsets.go
@@ -9,6 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
@@ -45,8 +46,9 @@ func RenderPrHelperContainer(image string, pullPolicy corev1.PullPolicy) corev1.
 			},
 		},
 		SecurityContext: &corev1.SecurityContext{
-			RunAsUser:  pointer.Int64(util.RootUser),
-			Privileged: pointer.Bool(true),
+			ReadOnlyRootFilesystem: pointer.Bool(true),
+			RunAsUser:              pointer.Int64(util.RootUser),
+			Privileged:             pointer.Bool(true),
 		},
 	}
 }
@@ -121,14 +123,62 @@ func NewHandlerDaemonSet(namespace, repository, imagePrefix, version, launcherVe
 			Image: launcherImage,
 			Name:  "virt-launcher",
 			SecurityContext: &corev1.SecurityContext{
-				Privileged: pointer.Bool(true),
+				ReadOnlyRootFilesystem: ptr.To(true),
+				Privileged:             pointer.Bool(true),
 			},
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					Name:      "node-labeller",
 					MountPath: nodeLabellerVolumePath,
 				},
+				{
+					Name:      "var-run-node-labeller",
+					MountPath: "/var/run",
+				},
+				{
+					Name:      "var-log-node-labeller",
+					MountPath: "/var/log/libvirt",
+				},
+				{
+					Name:      "etc-libvirt-node-labeller",
+					MountPath: "/etc/libvirt",
+				},
+				{
+					Name:      "var-lib-node-labeller",
+					MountPath: "/var/lib/libvirt",
+				},
+				{
+					Name:      "var-cache-node-labeller",
+					MountPath: "/var/cache/libvirt",
+				},
 			},
+		},
+	}
+
+	pod.Volumes = []corev1.Volume{
+		{
+			Name:         "var-run",
+			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+		},
+		{
+			Name:         "var-run-node-labeller",
+			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+		},
+		{
+			Name:         "var-log-node-labeller",
+			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+		},
+		{
+			Name:         "etc-libvirt-node-labeller",
+			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+		},
+		{
+			Name:         "var-lib-node-labeller",
+			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+		},
+		{
+			Name:         "var-cache-node-labeller",
+			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
 		},
 	}
 
@@ -152,6 +202,9 @@ func NewHandlerDaemonSet(namespace, repository, imagePrefix, version, launcherVe
 					corev1.ResourceCPU:    resource.MustParse("100m"),
 					corev1.ResourceMemory: resource.MustParse("20Mi"),
 				},
+			},
+			SecurityContext: &corev1.SecurityContext{
+				ReadOnlyRootFilesystem: ptr.To(true),
 			},
 		})
 	}
@@ -191,7 +244,8 @@ func NewHandlerDaemonSet(namespace, repository, imagePrefix, version, launcherVe
 		},
 	}
 	container.SecurityContext = &corev1.SecurityContext{
-		Privileged: pointer.Bool(true),
+		ReadOnlyRootFilesystem: pointer.Bool(true),
+		Privileged:             pointer.Bool(true),
 		SELinuxOptions: &corev1.SELinuxOptions{
 			Level: "s0",
 		},

--- a/pkg/virt-operator/resource/generate/components/deployments.go
+++ b/pkg/virt-operator/resource/generate/components/deployments.go
@@ -323,6 +323,19 @@ func NewApiServerDeployment(namespace, repository, imagePrefix, version, product
 	attachCertificateSecret(&deployment.Spec.Template.Spec, VirtHandlerCertSecretName, "/etc/virt-handler/clientcertificates")
 	attachProfileVolume(&deployment.Spec.Template.Spec)
 
+	volume := corev1.Volume{
+		Name: "tmp",
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	}
+	volumeMount := corev1.VolumeMount{
+		Name:      "tmp",
+		MountPath: "/tmp",
+	}
+	deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, volume)
+	deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[0].VolumeMounts, volumeMount)
+
 	pod := &deployment.Spec.Template.Spec
 	pod.ServiceAccountName = ApiServiceAccountName
 	pod.SecurityContext = &corev1.PodSecurityContext{
@@ -379,6 +392,7 @@ func NewApiServerDeployment(namespace, repository, imagePrefix, version, product
 
 	container.SecurityContext = &corev1.SecurityContext{
 		AllowPrivilegeEscalation: pointer.Bool(false),
+		ReadOnlyRootFilesystem:   pointer.Bool(true),
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{"ALL"},
 		},
@@ -476,6 +490,7 @@ func NewControllerDeployment(namespace, repository, imagePrefix, controllerVersi
 
 	container.SecurityContext = &corev1.SecurityContext{
 		AllowPrivilegeEscalation: pointer.Bool(false),
+		ReadOnlyRootFilesystem:   pointer.Bool(true),
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{"ALL"},
 		},
@@ -603,6 +618,7 @@ func NewOperatorDeployment(namespace, repository, imagePrefix, version, verbosit
 							},
 							SecurityContext: &corev1.SecurityContext{
 								AllowPrivilegeEscalation: pointer.Bool(false),
+								ReadOnlyRootFilesystem:   pointer.Bool(true),
 								Capabilities: &corev1.Capabilities{
 									Drop: []corev1.Capability{"ALL"},
 								},

--- a/pkg/virtctl/guestfs/guestfs.go
+++ b/pkg/virtctl/guestfs/guestfs.go
@@ -464,6 +464,7 @@ func createLibguestfsPod(pvc, image, cmd string, args []string, kvm, isBlock boo
 	}
 	allowPrivilegeEscalation := false
 	containerSecurityContext := &corev1.SecurityContext{
+		ReadOnlyRootFilesystem:   pointer.Bool(true),
 		AllowPrivilegeEscalation: &allowPrivilegeEscalation,
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{"ALL"},


### PR DESCRIPTION
## Description
As part of the integrity control task, we make all containers read-only, including Kubevirt containers, Containerized data importer containers.


## Why do we need it, and what problem does it solve?
These changes improve the ability for integrity checks. Improve security for containers.


## What is the expected result?
All containers from the d8-virtualization namespace, as well as all containers running in a custom namespace, must be created read-only.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

