### PR TITLE
feat: support vpc

### DIFF
--- a/pkg/network/admitter/netsource.go
+++ b/pkg/network/admitter/netsource.go
@@ -20,8 +20,6 @@
 package admitter
 
 import (
-	"fmt"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
 
@@ -30,19 +28,12 @@ import (
 	"kubevirt.io/kubevirt/pkg/network/vmispec"
 )
 
-func validateSinglePodNetwork(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec) []metav1.StatusCause {
+func validatePodNetwork(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec) []metav1.StatusCause {
 	var causes []metav1.StatusCause
 
 	podNetworks := vmispec.FilterNetworksSpec(spec.Networks, func(n v1.Network) bool {
 		return n.Pod != nil
 	})
-	if len(podNetworks) > 1 {
-		causes = append(causes, metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueDuplicate,
-			Message: fmt.Sprintf("more than one interface is connected to a pod network in %s", field.Child("interfaces").String()),
-			Field:   field.Child("interfaces").String(),
-		})
-	}
 
 	multusDefaultNetworks := vmispec.FilterNetworksSpec(spec.Networks, func(n v1.Network) bool {
 		return n.Multus != nil && n.Multus.Default

--- a/pkg/network/admitter/netsource_test.go
+++ b/pkg/network/admitter/netsource_test.go
@@ -31,25 +31,6 @@ import (
 )
 
 var _ = Describe("Validate network source", func() {
-	It("support only a single pod network", func() {
-		const net1Name = "default"
-		const net2Name = "default2"
-		vmi := v1.VirtualMachineInstance{}
-		vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
-			{Name: net1Name, InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}},
-			{Name: net2Name, InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}},
-		}
-		vmi.Spec.Networks = []v1.Network{
-			{Name: net1Name, NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}},
-			{Name: net2Name, NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}},
-		}
-		clusterConfig := stubClusterConfigChecker{bridgeBindingOnPodNetEnabled: true}
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vmi.Spec, clusterConfig)
-		causes := validator.Validate()
-		Expect(causes).To(HaveLen(1))
-		Expect(causes[0].Message).To(Equal("more than one interface is connected to a pod network in fake.interfaces"))
-	})
-
 	It("should reject when multiple types defined for a CNI network", func() {
 		spec := &v1.VirtualMachineInstanceSpec{}
 		spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}

--- a/pkg/network/admitter/validator.go
+++ b/pkg/network/admitter/validator.go
@@ -56,7 +56,7 @@ func NewValidator(field *k8sfield.Path, vmiSpec *v1.VirtualMachineInstanceSpec, 
 func (v Validator) Validate() []metav1.StatusCause {
 	var causes []metav1.StatusCause
 
-	causes = append(causes, validateSinglePodNetwork(v.field, v.vmiSpec)...)
+	causes = append(causes, validatePodNetwork(v.field, v.vmiSpec)...)
 	causes = append(causes, validateSingleNetworkSource(v.field, v.vmiSpec)...)
 	causes = append(causes, validateMultusNetworkSource(v.field, v.vmiSpec)...)
 	causes = append(causes, validateInterfaceStateValue(v.field, v.vmiSpec)...)

--- a/pkg/network/link/discovery.go
+++ b/pkg/network/link/discovery.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/vishvananda/netlink"
+	"kubevirt.io/client-go/log"
 
 	v1 "kubevirt.io/api/core/v1"
 
@@ -46,6 +47,11 @@ func DiscoverByNetwork(handler driver.NetworkHandler, networks []v1.Network, sub
 }
 
 func networkInterfaceNames(networks []v1.Network, subjectNetwork v1.Network) ([]string, error) {
+	if subjectNetwork.Pod != nil && subjectNetwork.Name != "default" {
+		log.DefaultLogger().Info(fmt.Sprintf("Pod network is not default, skip discovery, return [%q]", subjectNetwork.Name))
+		return []string{subjectNetwork.Name}, nil
+	}
+
 	ifaceName := namescheme.HashedPodInterfaceName(subjectNetwork)
 	ordinalIfaceName := namescheme.OrdinalPodInterfaceName(subjectNetwork.Name, networks)
 	if ordinalIfaceName == "" {

--- a/pkg/network/setup/netpod/discover.go
+++ b/pkg/network/setup/netpod/discover.go
@@ -40,6 +40,10 @@ func (n NetPod) discover(currentStatus *nmstate.Status) error {
 	podIfaceNameByVMINetwork := createNetworkNameScheme(n.vmiSpecNets, currentStatus.Interfaces)
 
 	for _, vmiSpecIface := range n.vmiSpecIfaces {
+		if skipPodInterfaceIsNotDefault(vmiSpecIface.Name, n.vmiSpecNets) {
+			continue
+		}
+
 		podIfaceName := podIfaceNameByVMINetwork[vmiSpecIface.Name]
 
 		// The discovery is not relevant for interfaces marked for removal.

--- a/pkg/network/setup/netpod/netpod.go
+++ b/pkg/network/setup/netpod/netpod.go
@@ -232,6 +232,10 @@ func (n NetPod) composeDesiredSpec(currentStatus *nmstate.Status) (*nmstate.Spec
 	spec := nmstate.Spec{Interfaces: []nmstate.Interface{}}
 
 	for ifIndex, iface := range n.vmiSpecIfaces {
+		if skipPodInterfaceIsNotDefault(iface.Name, n.vmiSpecNets) {
+			continue
+		}
+
 		var (
 			ifacesSpec []nmstate.Interface
 			err        error
@@ -533,6 +537,18 @@ func createNetworkNameScheme(networks []v1.Network, currentIfaces []nmstate.Inte
 		return namescheme.CreateOrdinalNetworkNameScheme(networks)
 	}
 	return namescheme.CreateHashedNetworkNameScheme(networks)
+}
+
+func skipPodInterfaceIsNotDefault(name string, networks []v1.Network) bool {
+	if name == "default" {
+		return false
+	}
+	for _, network := range networks {
+		if network.Name == name && network.Pod != nil {
+			return true
+		}
+	}
+	return false
 }
 
 func includesOrdinalNames(ifaces []nmstate.Interface) bool {


### PR DESCRIPTION
### What this PR does
Adds support for multiple network interfaces in PodNetwork.

### Before this PR:
Kubevirt did not support adding multiple pre-configured network interfaces to a PodNetwork.

### After this PR:
- Allows attaching additional network interfaces as fully prepared TunTap devices
- System skips interface creation for such subnets
- Default interface retains the reserved name "default"
