### PR TITLE
refactor: replace virtualmachine with new resource apivirtualmachines 

### DIFF
--- a/pkg/virt-operator/resource/generate/rbac/controller.go
+++ b/pkg/virt-operator/resource/generate/rbac/controller.go
@@ -368,8 +368,8 @@ func newControllerClusterRole() *rbacv1.ClusterRole {
 					"subresources.virtualization.deckhouse.io",
 				},
 				Resources: []string{
-					"virtualmachines/addvolume",
-					"virtualmachines/removevolume",
+					"apivirtualmachines/addvolume",
+					"apivirtualmachines/removevolume",
 				},
 				Verbs: []string{
 					"update",

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/core/v1/virtualmachineinstance_expansion.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/core/v1/virtualmachineinstance_expansion.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	vmiSubresourceURL               = "/apis/subresources.kubevirt.io/%s"
-	vmiSubresourceVirtualizationURL = "/apis/subresources.virtualization.deckhouse.io/v1alpha2" // v1alpha2/namespaces/%s/virtualmachines/%s/%s
+	vmiSubresourceVirtualizationURL = "/apis/subresources.virtualization.deckhouse.io/v1alpha2" // v1alpha2/namespaces/%s/apivirtualmachines/%s/%s
 )
 
 type SerialConsoleOptions struct {
@@ -274,7 +274,7 @@ func (c *virtualMachineInstances) AddVolume(ctx context.Context, name string, ad
 	return c.client.Put().
 		AbsPath(vmiSubresourceVirtualizationURL).
 		Namespace(c.ns).
-		Resource("virtualmachines").
+		Resource("apivirtualmachines").
 		Name(name).
 		SubResource("addvolume").
 		Body(body).
@@ -291,7 +291,7 @@ func (c *virtualMachineInstances) RemoveVolume(ctx context.Context, name string,
 	return c.client.Put().
 		AbsPath(vmiSubresourceVirtualizationURL).
 		Namespace(c.ns).
-		Resource("virtualmachines").
+		Resource("apivirtualmachines").
 		Name(name).
 		SubResource("removevolume").
 		Body(body).


### PR DESCRIPTION
### Description
replace virtualmachine with new resource apivirtualmachine

### What this PR does
Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

