### PR TITLE
chore: rename containers to support containerd integrity checks

### DIFF
--- a/pkg/container-disk/container-disk.go
+++ b/pkg/container-disk/container-disk.go
@@ -371,7 +371,7 @@ func generateContainerFromVolume(vmi *v1.VirtualMachineInstance, config *virtcon
 		Name:            name,
 		Image:           diskContainerImage,
 		ImagePullPolicy: volume.ContainerDisk.ImagePullPolicy,
-		Command:         []string{"/usr/bin/container-disk"},
+		Command:         []string{"/var/run/container-disk"},
 		Args:            args,
 		VolumeMounts: []kubev1.VolumeMount{
 			{
@@ -380,7 +380,7 @@ func generateContainerFromVolume(vmi *v1.VirtualMachineInstance, config *virtcon
 			},
 			{
 				Name:      binVolumeName,
-				MountPath: "/usr/bin",
+				MountPath: "/var/run",
 			},
 		},
 		Resources: resources,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -498,7 +498,7 @@ func IsPodReady(pod *k8sv1.Pod) bool {
 		// The compute container potentially holds a readiness probe for the VMI. Therefore
 		// don't wait for the compute container to become ready (the VMI later on will trigger the change to ready)
 		// and only check that the container started
-		if containerStatus.Name == "compute" {
+		if strings.HasSuffix(containerStatus.Name, "compute") {
 			if containerStatus.State.Running == nil {
 				return false
 			}
@@ -528,7 +528,7 @@ func IsPodFailedOrGoingDown(pod *k8sv1.Pod) bool {
 
 func isComputeContainerDown(pod *k8sv1.Pod) bool {
 	for _, containerStatus := range pod.Status.ContainerStatuses {
-		if containerStatus.Name == "compute" {
+		if strings.HasSuffix(containerStatus.Name, "compute") {
 			return containerStatus.State.Terminated != nil
 		}
 	}
@@ -537,7 +537,7 @@ func isComputeContainerDown(pod *k8sv1.Pod) bool {
 
 func isComputeContainerFailed(pod *k8sv1.Pod) bool {
 	for _, containerStatus := range pod.Status.ContainerStatuses {
-		if containerStatus.Name == "compute" {
+		if strings.HasSuffix(containerStatus.Name, "compute") {
 			return containerStatus.State.Terminated != nil && containerStatus.State.Terminated.ExitCode != 0
 		}
 	}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Controller", func() {
 						Phase: k8sv1.PodRunning,
 						ContainerStatuses: []k8sv1.ContainerStatus{
 							{
-								Name: "compute",
+								Name: "d8v-compute",
 								State: k8sv1.ContainerState{
 									Running:    &k8sv1.ContainerStateRunning{},
 									Terminated: &k8sv1.ContainerStateTerminated{},
@@ -74,7 +74,7 @@ var _ = Describe("Controller", func() {
 						Phase: k8sv1.PodRunning,
 						ContainerStatuses: []k8sv1.ContainerStatus{
 							{
-								Name:  "compute",
+								Name:  "d8v-compute",
 								State: k8sv1.ContainerState{},
 							},
 						},
@@ -89,7 +89,7 @@ var _ = Describe("Controller", func() {
 						Phase: k8sv1.PodRunning,
 						ContainerStatuses: []k8sv1.ContainerStatus{
 							{
-								Name: "compute",
+								Name: "d8v-compute",
 								State: k8sv1.ContainerState{
 									Running: &k8sv1.ContainerStateRunning{},
 								},
@@ -110,7 +110,7 @@ var _ = Describe("Controller", func() {
 						Phase: k8sv1.PodRunning,
 						ContainerStatuses: []k8sv1.ContainerStatus{
 							{
-								Name: "compute",
+								Name: "d8v-compute",
 								State: k8sv1.ContainerState{
 									Running: &k8sv1.ContainerStateRunning{},
 								},
@@ -157,7 +157,7 @@ var _ = Describe("Controller", func() {
 						Phase: k8sv1.PodRunning,
 						ContainerStatuses: []k8sv1.ContainerStatus{
 							{
-								Name: "compute",
+								Name: "d8v-compute",
 								State: k8sv1.ContainerState{
 									Terminated: &k8sv1.ContainerStateTerminated{
 										ExitCode: int32(1),

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -336,7 +336,7 @@ var _ = Describe("Template", func() {
 				Entry("and contain default container for logging and exec",
 					map[string]string{},
 					map[string]string{
-						"kubectl.kubernetes.io/default-container": "compute",
+						"kubectl.kubernetes.io/default-container": "d8v-compute",
 					},
 				),
 			)
@@ -421,12 +421,12 @@ var _ = Describe("Template", func() {
 					v1.DomainAnnotation:                                  "testvmi",
 					"test":                                               "shouldBeInPod",
 					hooks.HookSidecarListAnnotationName:                  `[{"image": "some-image:v1", "imagePullPolicy": "IfNotPresent"}]`,
-					"pre.hook.backup.velero.io/container":                "compute",
+					"pre.hook.backup.velero.io/container":                "d8v-compute",
 					"pre.hook.backup.velero.io/command":                  "[\"/usr/bin/virt-freezer\", \"--freeze\", \"--name\", \"testvmi\", \"--namespace\", \"testns\"]",
-					"post.hook.backup.velero.io/container":               "compute",
+					"post.hook.backup.velero.io/container":               "d8v-compute",
 					"post.hook.backup.velero.io/command":                 "[\"/usr/bin/virt-freezer\", \"--unfreeze\", \"--name\", \"testvmi\", \"--namespace\", \"testns\"]",
 					"kubevirt.io/migrationTransportUnix":                 "true",
-					"kubectl.kubernetes.io/default-container":            "compute",
+					"kubectl.kubernetes.io/default-container":            "d8v-compute",
 					"descheduler.alpha.kubernetes.io/request-evict-only": "",
 				}))
 				Expect(pod.ObjectMeta.OwnerReferences).To(Equal([]metav1.OwnerReference{{
@@ -571,7 +571,7 @@ var _ = Describe("Template", func() {
 				pod, err := svc.RenderLaunchManifest(&vmi)
 				Expect(err).ToNot(HaveOccurred())
 				for _, c := range pod.Spec.Containers {
-					if c.Name != "compute" {
+					if c.Name != "d8v-compute" {
 						if enableWorkaround {
 							Expect(c.SecurityContext.SELinuxOptions.Level).To(Equal("s0"), "failed on "+c.Name)
 						} else {
@@ -2631,7 +2631,7 @@ var _ = Describe("Template", func() {
 				pod, err := svc.RenderLaunchManifest(&vmi)
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(pod.Spec.Containers[0].Name).To(Equal("compute"))
+				Expect(pod.Spec.Containers[0].Name).To(Equal("d8v-compute"))
 				volumeMountNames := make([]string, len(pod.Spec.Containers[0].VolumeMounts))
 				for _, volumeMount := range pod.Spec.Containers[0].VolumeMounts {
 					volumeMountNames = append(volumeMountNames, volumeMount.Name)
@@ -2727,7 +2727,7 @@ var _ = Describe("Template", func() {
 				pod, err := svc.RenderLaunchManifest(&vmi)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.Containers[0].Image).To(Equal("kubevirt/virt-launcher"))
-				Expect(pod.Spec.Containers[0].Name).To(Equal("compute"))
+				Expect(pod.Spec.Containers[0].Name).To(Equal("d8v-compute"))
 				Expect(pod.Spec.Containers[1].Name).To(Equal("volumecontainerdisk1"))
 			})
 		})
@@ -3700,7 +3700,7 @@ var _ = Describe("Template", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				computeContainer := pod.Spec.Containers[0]
-				Expect(computeContainer.Name).To(Equal("compute"))
+				Expect(computeContainer.Name).To(Equal("d8v-compute"))
 
 				if defineEphemeralStorageLimit {
 					Expect(computeContainer.Resources.Requests).To(HaveKeyWithValue(k8sv1.ResourceEphemeralStorage, ephemeralStorageRequests))
@@ -3740,7 +3740,7 @@ var _ = Describe("Template", func() {
 				containers := pod.Spec.Containers
 				initContainers := pod.Spec.InitContainers
 
-				Expect(hasContainerWithName(initContainers, "container-disk-binary")).To(BeTrue())
+				Expect(hasContainerWithName(initContainers, "d8v-container-disk-binary")).To(BeTrue())
 				Expect(hasContainerWithName(initContainers, "kernel-boot")).To(BeTrue())
 				Expect(hasContainerWithName(containers, "kernel-boot")).To(BeTrue())
 			})
@@ -3798,7 +3798,7 @@ var _ = Describe("Template", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			for _, container := range pod.Spec.Containers {
-				if container.Name == "compute" {
+				if container.Name == "d8v-compute" {
 					Expect(container.SecurityContext.Capabilities.Add).To(ContainElement(k8sv1.Capability("NET_BIND_SERVICE")))
 					return
 				}
@@ -3822,7 +3822,7 @@ var _ = Describe("Template", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			for _, container := range pod.Spec.Containers {
-				if container.Name == "compute" {
+				if container.Name == "d8v-compute" {
 					Expect(container.SecurityContext.Capabilities.Add).To(
 						ContainElement(k8sv1.Capability("NET_BIND_SERVICE")))
 					return
@@ -3852,12 +3852,12 @@ var _ = Describe("Template", func() {
 		},
 			Entry("on a root virt-launcher", func() *v1.VirtualMachineInstance {
 				return api.NewMinimalVMI("fake-vmi")
-			}, "compute", []k8sv1.Capability{CAP_NET_BIND_SERVICE, CAP_SYS_NICE}, nil),
+			}, "d8v-compute", []k8sv1.Capability{CAP_NET_BIND_SERVICE, CAP_SYS_NICE}, nil),
 			Entry("on a non-root virt-launcher", func() *v1.VirtualMachineInstance {
 				vmi := api.NewMinimalVMI("fake-vmi")
 				vmi.Status.RuntimeUser = uint64(nonRootUser)
 				return vmi
-			}, "compute", []k8sv1.Capability{CAP_NET_BIND_SERVICE}, []k8sv1.Capability{"ALL"}),
+			}, "d8v-compute", []k8sv1.Capability{CAP_NET_BIND_SERVICE}, []k8sv1.Capability{"ALL"}),
 			Entry("on a sidecar container", func() *v1.VirtualMachineInstance {
 				vmi := api.NewMinimalVMI("fake-vmi")
 				vmi.Status.RuntimeUser = uint64(nonRootUser)
@@ -4144,7 +4144,7 @@ var _ = Describe("Template", func() {
 			}
 
 			for _, container := range pod.Spec.Containers {
-				if container.Name == "compute" {
+				if container.Name == "d8v-compute" {
 					continue
 				}
 				Expect(*container.SecurityContext.RunAsNonRoot).To(BeTrue())
@@ -4570,7 +4570,7 @@ var _ = Describe("Template", func() {
 				pod, err := svc.RenderLaunchManifest(&vmi)
 				Expect(err).ToNot(HaveOccurred())
 				cpuRequests := resource.MustParse("200m")
-				Expect(pod.Spec.Containers[0].Name).To(Equal("compute"))
+				Expect(pod.Spec.Containers[0].Name).To(Equal("d8v-compute"))
 				Expect(pod.Spec.Containers[0].Resources.Requests.Cpu().Cmp(cpuRequests)).To(BeZero())
 				Expect(pod.Spec.Containers[0].Resources.Limits.Cpu().IsZero()).To(BeTrue())
 			})
@@ -4606,7 +4606,7 @@ var _ = Describe("Template", func() {
 				pod, err := svc.RenderLaunchManifest(&vmi)
 				Expect(err).ToNot(HaveOccurred())
 				cpuLimit := resource.MustParse("2")
-				Expect(pod.Spec.Containers[0].Name).To(Equal("compute"))
+				Expect(pod.Spec.Containers[0].Name).To(Equal("d8v-compute"))
 				Expect(pod.Spec.Containers[0].Resources.Requests.Cpu().Cmp(cpuRequests)).To(BeZero())
 				Expect(pod.Spec.Containers[0].Resources.Limits.Cpu().Cmp(cpuLimit)).To(BeZero())
 			})
@@ -4649,7 +4649,7 @@ var _ = Describe("Template", func() {
 
 						pod, err := svc.RenderLaunchManifest(&vmi)
 						Expect(err).ToNot(HaveOccurred())
-						Expect(pod.Spec.Containers[0].Name).To(Equal("compute"))
+						Expect(pod.Spec.Containers[0].Name).To(Equal("d8v-compute"))
 						Expect(pod.Spec.Containers[0].Resources.Limits.Cpu().Value()).To(BeEquivalentTo(expectedCPU.Value()))
 					})
 				})
@@ -4676,7 +4676,7 @@ var _ = Describe("Template", func() {
 
 						pod, err := svc.RenderLaunchManifest(&vmi)
 						Expect(err).ToNot(HaveOccurred())
-						Expect(pod.Spec.Containers[0].Name).To(Equal("compute"))
+						Expect(pod.Spec.Containers[0].Name).To(Equal("d8v-compute"))
 						Expect(pod.Spec.Containers[0].Resources.Limits.Cpu().Value()).To(BeEquivalentTo(2))
 					})
 				})
@@ -4713,7 +4713,7 @@ var _ = Describe("Template", func() {
 					pod, err := svc.RenderLaunchManifest(&vmi)
 					Expect(err).ToNot(HaveOccurred())
 					cpuRequests := resource.MustParse("200m")
-					Expect(pod.Spec.Containers[0].Name).To(Equal("compute"))
+					Expect(pod.Spec.Containers[0].Name).To(Equal("d8v-compute"))
 					Expect(pod.Spec.Containers[0].Resources.Requests.Cpu().Cmp(cpuRequests)).To(BeZero())
 					Expect(pod.Spec.Containers[0].Resources.Limits.Cpu().IsZero()).To(BeTrue())
 				})
@@ -4787,7 +4787,7 @@ var _ = Describe("Template", func() {
 
 				pod, err := svc.RenderLaunchManifest(&vmi)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(pod.Spec.Containers[0].Name).To(Equal("compute"))
+				Expect(pod.Spec.Containers[0].Name).To(Equal("d8v-compute"))
 				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().Value()).To(BeZero())
 			})
 		})
@@ -4827,7 +4827,7 @@ var _ = Describe("Template", func() {
 
 					pod, err := svc.RenderLaunchManifest(&vmi)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(pod.Spec.Containers[0].Name).To(Equal("compute"))
+					Expect(pod.Spec.Containers[0].Name).To(Equal("d8v-compute"))
 					expectedMemory := resource.NewScaledQuantity(0, resource.Kilo)
 					expectedMemory.Add(GetMemoryOverhead(&vmi, defaultArch, config.GetConfig().AdditionalGuestMemoryOverheadRatio))
 					expectedMemory.Add(guestMemory)
@@ -4856,7 +4856,7 @@ var _ = Describe("Template", func() {
 
 						pod, err := svc.RenderLaunchManifest(&vmi)
 						Expect(err).ToNot(HaveOccurred())
-						Expect(pod.Spec.Containers[0].Name).To(Equal("compute"))
+						Expect(pod.Spec.Containers[0].Name).To(Equal("d8v-compute"))
 						expectedValue := int64(float64(pod.Spec.Containers[0].Resources.Requests.Memory().Value()) * DefaultMemoryLimitOverheadRatio)
 						Expect(pod.Spec.Containers[0].Resources.Limits.Memory().Value()).To(BeEquivalentTo(expectedValue))
 					})
@@ -4908,7 +4908,7 @@ var _ = Describe("Template", func() {
 
 							pod, err := svc.RenderLaunchManifest(&vmi)
 							Expect(err).ToNot(HaveOccurred())
-							Expect(pod.Spec.Containers[0].Name).To(Equal("compute"))
+							Expect(pod.Spec.Containers[0].Name).To(Equal("d8v-compute"))
 							expectedValue := int64(float64(pod.Spec.Containers[0].Resources.Requests.Memory().Value()) * expectedUsedRatio)
 							Expect(pod.Spec.Containers[0].Resources.Limits.Memory().Value()).To(BeEquivalentTo(expectedValue))
 						},
@@ -4938,7 +4938,7 @@ var _ = Describe("Template", func() {
 
 					pod, err := svc.RenderLaunchManifest(&vmi)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(pod.Spec.Containers[0].Name).To(Equal("compute"))
+					Expect(pod.Spec.Containers[0].Name).To(Equal("d8v-compute"))
 					Expect(pod.Spec.Containers[0].Resources.Limits.Memory().Value()).To(BeZero())
 				})
 			})
@@ -4999,7 +4999,7 @@ var _ = Describe("Template", func() {
 			Expect(pod.Spec.Volumes).ToNot(ContainElement(networkInfoAnnotVolume()),
 				"pod should not have network-info annotation volume")
 
-			Expect(pod.Spec.Containers[0].Name).To(Equal("compute"))
+			Expect(pod.Spec.Containers[0].Name).To(Equal("d8v-compute"))
 			Expect(pod.Spec.Containers[0].VolumeMounts).ToNot(ContainElement(networkInfoAnnotVolumeMount()),
 				"pod should not have network-info annotation volume mount")
 		})
@@ -5018,7 +5018,7 @@ var _ = Describe("Template", func() {
 				Expect(netInfoVolumes).To(ConsistOf(networkInfoAnnotVolume()),
 					"should have single network-info annotation volume")
 
-				const computeContainerName = "compute"
+				const computeContainerName = "d8v-compute"
 				Expect(pod.Spec.Containers[0].Name).To(Equal(computeContainerName))
 				netInfoVolumeMounts := filterVolumeMountByName(pod.Spec.Containers[0].VolumeMounts, netInfoAnnotVolName)
 				Expect(netInfoVolumeMounts).To(ConsistOf(networkInfoAnnotVolumeMount()),

--- a/pkg/virt-controller/watch/drain/evacuation/evacuation_test.go
+++ b/pkg/virt-controller/watch/drain/evacuation/evacuation_test.go
@@ -594,7 +594,7 @@ func newPod(vmi *v1.VirtualMachineInstance, name string, phase k8scorev1.PodPhas
 		Status: k8scorev1.PodStatus{
 			Phase: phase,
 			ContainerStatuses: []k8scorev1.ContainerStatus{
-				{Ready: false, Name: "compute", State: k8scorev1.ContainerState{Running: &k8scorev1.ContainerStateRunning{}}},
+				{Ready: false, Name: "d8v-compute", State: k8scorev1.ContainerState{Running: &k8scorev1.ContainerStateRunning{}}},
 			},
 		},
 	}

--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -711,7 +711,7 @@ func (c *MigrationController) createTargetPod(migration *virtv1.VirtualMachineIn
 	computeImageOverride, ok := migration.Annotations[virtv1.FuncTestMigrationTargetImageOverrideAnnotation]
 	if ok && computeImageOverride != "" {
 		for i, container := range templatePod.Spec.Containers {
-			if container.Name == "compute" {
+			if strings.HasSuffix(container.Name, "compute") {
 				container.Image = computeImageOverride
 				templatePod.Spec.Containers[i] = container
 				break
@@ -2063,7 +2063,7 @@ func (c *MigrationController) removeHandOffKey(migrationKey string) {
 
 func getComputeContainer(pod *k8sv1.Pod) *k8sv1.Container {
 	for _, container := range pod.Spec.Containers {
-		if container.Name == "compute" {
+		if strings.HasSuffix(container.Name, "compute") {
 			return &container
 		}
 	}

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -118,7 +118,7 @@ var _ = Describe("Migration watcher", func() {
 
 	expectAttachmentPodCreation := func(namespace, migrationUid string) {
 		pods, err := kubeClient.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("%s=%s,%s=%s", virtv1.MigrationJobLabel, migrationUid, virtv1.AppLabel, "hotplug-disk"),
+			LabelSelector: fmt.Sprintf("%s=%s,%s=%s", virtv1.MigrationJobLabel, migrationUid, virtv1.AppLabel, "d8v-hotplug-disk"),
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(pods.Items).To(HaveLen(1))
@@ -458,7 +458,7 @@ var _ = Describe("Migration watcher", func() {
 			migration.Status.Phase = virtv1.MigrationScheduled
 			targetPod.Spec.NodeName = "node01"
 			targetPod.Status.ContainerStatuses = []k8sv1.ContainerStatus{{
-				Name: "compute", State: k8sv1.ContainerState{Running: &k8sv1.ContainerStateRunning{}},
+				Name: "d8v-compute", State: k8sv1.ContainerState{Running: &k8sv1.ContainerStateRunning{}},
 			}}
 
 			addMigration(migration)
@@ -531,7 +531,7 @@ var _ = Describe("Migration watcher", func() {
 					})
 
 				targetPod.Spec.Containers = append(targetPod.Spec.Containers, k8sv1.Container{
-					Name: "compute",
+					Name: "d8v-compute",
 					Resources: k8sv1.ResourceRequirements{
 						Requests: k8sv1.ResourceList{
 							k8sv1.ResourceCPU: resource.MustParse("4"),
@@ -542,7 +542,7 @@ var _ = Describe("Migration watcher", func() {
 					},
 				})
 				targetPod.Status.ContainerStatuses = []k8sv1.ContainerStatus{{
-					Name: "compute", State: k8sv1.ContainerState{Running: &k8sv1.ContainerStateRunning{}},
+					Name: "d8v-compute", State: k8sv1.ContainerState{Running: &k8sv1.ContainerStateRunning{}},
 				}}
 
 				addMigration(migration)
@@ -581,7 +581,7 @@ var _ = Describe("Migration watcher", func() {
 					})
 
 				targetPod.Spec.Containers = append(targetPod.Spec.Containers, k8sv1.Container{
-					Name: "compute",
+					Name: "d8v-compute",
 					Resources: k8sv1.ResourceRequirements{
 						Requests: k8sv1.ResourceList{
 							k8sv1.ResourceMemory: resource.MustParse("150Mi"),
@@ -589,7 +589,7 @@ var _ = Describe("Migration watcher", func() {
 					},
 				})
 				targetPod.Status.ContainerStatuses = []k8sv1.ContainerStatus{{
-					Name: "compute", State: k8sv1.ContainerState{Running: &k8sv1.ContainerStateRunning{}},
+					Name: "d8v-compute", State: k8sv1.ContainerState{Running: &k8sv1.ContainerStateRunning{}},
 				}}
 
 				if hugepages != nil {
@@ -1206,12 +1206,12 @@ var _ = Describe("Migration watcher", func() {
 		},
 			Entry("with running compute container and no infra container",
 				[]k8sv1.ContainerStatus{{
-					Name: "compute", State: k8sv1.ContainerState{Running: &k8sv1.ContainerStateRunning{}},
+					Name: "d8v-compute", State: k8sv1.ContainerState{Running: &k8sv1.ContainerStateRunning{}},
 				}},
 			),
 			Entry("with running compute container and no ready istio-proxy container",
 				[]k8sv1.ContainerStatus{{
-					Name: "compute", State: k8sv1.ContainerState{Running: &k8sv1.ContainerStateRunning{}},
+					Name: "d8v-compute", State: k8sv1.ContainerState{Running: &k8sv1.ContainerStateRunning{}},
 				}, {Name: "istio-proxy", State: k8sv1.ContainerState{Running: &k8sv1.ContainerStateRunning{}}, Ready: false}},
 			),
 		)
@@ -1234,10 +1234,10 @@ var _ = Describe("Migration watcher", func() {
 			expectVirtualMachineInstanceMigrationState(vmi.Namespace, vmi.Name, BeNil())
 		},
 			Entry("with not ready infra container and not ready compute container",
-				[]k8sv1.ContainerStatus{{Name: "compute", Ready: false}, {Name: "kubevirt-infra", Ready: false}},
+				[]k8sv1.ContainerStatus{{Name: "d8v-compute", Ready: false}, {Name: "kubevirt-infra", Ready: false}},
 			),
 			Entry("with not ready compute container and no infra container",
-				[]k8sv1.ContainerStatus{{Name: "compute", Ready: false}},
+				[]k8sv1.ContainerStatus{{Name: "d8v-compute", Ready: false}},
 			),
 		)
 
@@ -1249,7 +1249,7 @@ var _ = Describe("Migration watcher", func() {
 			targetPod := newTargetPodForVirtualMachine(vmi, migration, k8sv1.PodRunning)
 			targetPod.Spec.NodeName = "node01"
 			targetPod.Status.ContainerStatuses = []k8sv1.ContainerStatus{{
-				Name: "compute", State: k8sv1.ContainerState{Running: &k8sv1.ContainerStateRunning{}},
+				Name: "d8v-compute", State: k8sv1.ContainerState{Running: &k8sv1.ContainerStateRunning{}},
 			}}
 
 			addMigration(migration)
@@ -1280,7 +1280,7 @@ var _ = Describe("Migration watcher", func() {
 			targetPod := newTargetPodForVirtualMachine(vmi, migration, k8sv1.PodRunning)
 			targetPod.Spec.NodeName = "node01"
 			targetPod.Status.ContainerStatuses = []k8sv1.ContainerStatus{{
-				Name: "compute", State: k8sv1.ContainerState{Running: &k8sv1.ContainerStateRunning{}},
+				Name: "d8v-compute", State: k8sv1.ContainerState{Running: &k8sv1.ContainerStateRunning{}},
 			}}
 
 			addMigration(migration)
@@ -1855,7 +1855,7 @@ var _ = Describe("Migration watcher", func() {
 			targetPod = newTargetPodForVirtualMachine(vmi, migration, k8sv1.PodRunning)
 			targetPod.Spec.NodeName = "node01"
 			targetPod.Status.ContainerStatuses = []k8sv1.ContainerStatus{{
-				Name: "compute", State: k8sv1.ContainerState{Running: &k8sv1.ContainerStateRunning{}},
+				Name: "d8v-compute", State: k8sv1.ContainerState{Running: &k8sv1.ContainerStateRunning{}},
 			}}
 
 			By("Defining migration policy, matching it to vmi to posting it into the cluster")
@@ -2376,7 +2376,7 @@ func newAttachmentPodForVirtualMachine(ownerPod *k8sv1.Pod, migration *virtv1.Vi
 			Namespace: ownerPod.Namespace,
 			UID:       "test-uid",
 			Labels: map[string]string{
-				virtv1.AppLabel:          "hotplug-disk",
+				virtv1.AppLabel:          "d8v-hotplug-disk",
 				virtv1.MigrationJobLabel: string(migration.UID),
 			},
 			Annotations: map[string]string{

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -527,7 +527,7 @@ func (c *VMIController) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8
 	if vmiPodExists {
 		var foundImage string
 		for _, container := range pod.Spec.Containers {
-			if container.Name == "compute" {
+			if strings.HasSuffix(container.Name, "compute") {
 				foundImage = container.Image
 				break
 			}
@@ -2296,7 +2296,7 @@ func (c *VMIController) updateVolumeStatus(vmi *virtv1.VirtualMachineInstance, v
 				} else if volume.PersistentVolumeClaim != nil {
 					var isReady bool
 					for _, cs := range attachmentPod.Status.ContainerStatuses {
-						if cs.Name == "hotplug-disk" {
+						if cs.Name == "d8v-hotplug-disk" {
 							isReady = cs.Ready
 							break
 						}

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -395,7 +395,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			IsPodWithoutVmPayload := WithTransform(
 				func(pod *k8sv1.Pod) string {
 					for _, c := range pod.Spec.Containers {
-						if c.Name == "compute" {
+						if c.Name == "d8v-compute" {
 							return strings.Join(c.Command, " ")
 						}
 					}
@@ -671,7 +671,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			IsPodWithoutVmPayload := WithTransform(
 				func(pod *k8sv1.Pod) string {
 					for _, c := range pod.Spec.Containers {
-						if c.Name == "compute" {
+						if c.Name == "d8v-compute" {
 							return strings.Join(c.Command, " ")
 						}
 					}
@@ -1285,12 +1285,12 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		},
 			Entry("with running compute container and no infra container",
 				[]k8sv1.ContainerStatus{{
-					Name: "compute", State: k8sv1.ContainerState{Running: &k8sv1.ContainerStateRunning{}},
+					Name: "d8v-compute", State: k8sv1.ContainerState{Running: &k8sv1.ContainerStateRunning{}},
 				}},
 			),
 			Entry("with running compute container and no ready istio-proxy container",
 				[]k8sv1.ContainerStatus{{
-					Name: "compute", State: k8sv1.ContainerState{Running: &k8sv1.ContainerStateRunning{}},
+					Name: "d8v-compute", State: k8sv1.ContainerState{Running: &k8sv1.ContainerStateRunning{}},
 				}, {Name: "istio-proxy", State: k8sv1.ContainerState{Running: &k8sv1.ContainerStateRunning{}}, Ready: false}},
 			),
 		)
@@ -1312,10 +1312,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			expectVMITimestamp(vmi.Namespace, vmi.Name, BeEmpty())
 		},
 			Entry("with not ready infra container and not ready compute container",
-				[]k8sv1.ContainerStatus{{Name: "compute", Ready: false}, {Name: "kubevirt-infra", Ready: false}},
+				[]k8sv1.ContainerStatus{{Name: "d8v-compute", Ready: false}, {Name: "kubevirt-infra", Ready: false}},
 			),
 			Entry("with not ready compute container and no infra container",
-				[]k8sv1.ContainerStatus{{Name: "compute", Ready: false}},
+				[]k8sv1.ContainerStatus{{Name: "d8v-compute", Ready: false}},
 			),
 		)
 
@@ -1348,7 +1348,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			setReadyCondition(vmi, k8sv1.ConditionFalse, virtv1.GuestNotRunningReason)
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 			pod.Status.ContainerStatuses = []k8sv1.ContainerStatus{{
-				Name: "compute", State: k8sv1.ContainerState{Running: &k8sv1.ContainerStateRunning{}},
+				Name: "d8v-compute", State: k8sv1.ContainerState{Running: &k8sv1.ContainerStateRunning{}},
 			}}
 			attachmentPod := NewPodForVirtlauncher(pod, "hp-test", "abcd", attachmentPodPhase)
 			attachmentPod.Spec.Volumes = append(attachmentPod.Spec.Volumes, k8sv1.Volume{
@@ -1562,7 +1562,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
 			setReadyCondition(vmi, k8sv1.ConditionFalse, virtv1.PodTerminatingReason)
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodPending)
-			pod.Status.ContainerStatuses = []k8sv1.ContainerStatus{{Name: "compute", State: k8sv1.ContainerState{Terminated: &k8sv1.ContainerStateTerminated{}}}}
+			pod.Status.ContainerStatuses = []k8sv1.ContainerStatus{{Name: "d8v-compute", State: k8sv1.ContainerState{Terminated: &k8sv1.ContainerStateTerminated{}}}}
 			vmi.Status.Phase = virtv1.Scheduling
 
 			addVirtualMachine(vmi)
@@ -1683,7 +1683,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			pod.Spec.Containers = append(pod.Spec.Containers, k8sv1.Container{
 				Image: "madeup",
-				Name:  "compute",
+				Name:  "d8v-compute",
 			})
 
 			addVirtualMachine(vmi)
@@ -1718,7 +1718,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			pod.Spec.Containers = append(pod.Spec.Containers, k8sv1.Container{
 				Image: controller.templateService.GetLauncherImage(),
-				Name:  "compute",
+				Name:  "d8v-compute",
 			})
 
 			addVirtualMachine(vmi)
@@ -4004,7 +4004,7 @@ func NewPodForVirtualMachine(vmi *virtv1.VirtualMachineInstance, phase k8sv1.Pod
 		Status: k8sv1.PodStatus{
 			Phase: phase,
 			ContainerStatuses: []k8sv1.ContainerStatus{
-				{Ready: false, Name: "compute", State: k8sv1.ContainerState{Running: &k8sv1.ContainerStateRunning{}}},
+				{Ready: false, Name: "d8v-compute", State: k8sv1.ContainerState{Running: &k8sv1.ContainerStateRunning{}}},
 			},
 			Conditions: []k8sv1.PodCondition{
 				{

--- a/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
@@ -631,7 +631,7 @@ func newVirtualMachine(name string, isMigratable bool, image string, vmiSource *
 		Status: k8sv1.PodStatus{
 			Phase: k8sv1.PodRunning,
 			ContainerStatuses: []k8sv1.ContainerStatus{
-				{Ready: false, Name: "compute", State: k8sv1.ContainerState{Running: &k8sv1.ContainerStateRunning{}}},
+				{Ready: false, Name: "d8v-compute", State: k8sv1.ContainerState{Running: &k8sv1.ContainerStateRunning{}}},
 			},
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

1. Use /usr/bin directory to copy container-disk binary into "container disk" container.
2. Use original kubevirt names for containers in Pods in user namespace, e.g. "compute" in virt-launcher, "hotplug-disk" in hp pod.

After this PR:

1. Use /var/run directory to copy container-disk binary. This directory pre-created by containerd with integrity check enabled.
2. USe prefixed containers names: d8v-compute, d8v-hotplug-disk, etc.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note

```

