### PR TITLE
fix(core): replace kvm64 with qemu64

### DIFF
--- a/pkg/virt-controller/services/nodeselectorrenderer.go
+++ b/pkg/virt-controller/services/nodeselectorrenderer.go
@@ -24,7 +24,7 @@ type NodeSelectorRenderer struct {
 type NodeSelectorRendererOption func(renderer *NodeSelectorRenderer)
 
 // DeckhouseVirtualizationPlatformGenericCPUModel is a name of additional empty CPU model for Discovery type of VMClass.
-const DeckhouseVirtualizationPlatformGenericCPUModel = "kvm64"
+const DeckhouseVirtualizationPlatformGenericCPUModel = "qemu64"
 
 func NewNodeSelectorRenderer(
 	vmiNodeSelectors map[string]string,

--- a/pkg/virt-controller/services/nodeselectorrenderer.go
+++ b/pkg/virt-controller/services/nodeselectorrenderer.go
@@ -25,6 +25,7 @@ type NodeSelectorRendererOption func(renderer *NodeSelectorRenderer)
 
 // DeckhouseVirtualizationPlatformGenericCPUModel is a name of additional empty CPU model for Discovery type of VMClass.
 const DeckhouseVirtualizationPlatformGenericCPUModel = "qemu64"
+const DeckhouseVirtualizationPlatformLegacyGenericCPUModel = "kvm64"
 
 func NewNodeSelectorRenderer(
 	vmiNodeSelectors map[string]string,
@@ -55,7 +56,7 @@ func (nsr *NodeSelectorRenderer) Render() map[string]string {
 		maps.Copy(nsr.podNodeSelectors, hypervNodeSelectors(nsr.vmiFeatures))
 	}
 	// Prevent adding node selector for host-model, host-passthrough and an empty CPU model.
-	if nsr.cpuModelLabel != "" && nsr.cpuModelLabel != cpuModelLabel(v1.CPUModeHostModel) && nsr.cpuModelLabel != cpuModelLabel(v1.CPUModeHostPassthrough) && nsr.cpuModelLabel != cpuModelLabel(DeckhouseVirtualizationPlatformGenericCPUModel) {
+	if nsr.cpuModelLabel != "" && nsr.cpuModelLabel != cpuModelLabel(v1.CPUModeHostModel) && nsr.cpuModelLabel != cpuModelLabel(v1.CPUModeHostPassthrough) && nsr.cpuModelLabel != cpuModelLabel(DeckhouseVirtualizationPlatformGenericCPUModel) && nsr.cpuModelLabel != cpuModelLabel(DeckhouseVirtualizationPlatformLegacyGenericCPUModel) {
 		nsr.enableSelectorLabel(nsr.cpuModelLabel)
 	}
 	for _, cpuFeatureLabel := range nsr.cpuFeatureLabels {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

Replace kvm64 with qemu64 because of issued related to AMD CPUs and because kvm64 is not recommended by [qemu docs](https://www.qemu.org/docs/master/system/i386/cpu.html#other-non-recommended-x86-cpus)

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

