### PR TITLE
chore: sort customizeComponents.flags

### DIFF
--- a/pkg/virt-operator/resource/apply/patches.go
+++ b/pkg/virt-operator/resource/apply/patches.go
@@ -72,10 +72,16 @@ func addFlagsPatch(name, resource string, flags map[string]string, patches []v1.
 func flagsToArray(flags map[string]string) []string {
 	farr := make([]string, 0)
 
-	for flag, v := range flags {
+	fnames := make([]string, 0, len(flags))
+	for flag := range flags {
+		fnames = append(fnames, flag)
+	}
+	sort.Strings(fnames)
+
+	for _, flag := range fnames {
 		farr = append(farr, fmt.Sprintf("--%s", strings.ToLower(flag)))
-		if v != "" {
-			farr = append(farr, v)
+		if flags[flag] != "" {
+			farr = append(farr, flags[flag])
 		}
 	}
 


### PR DESCRIPTION
Converting from map to array in flagsToArray may change flags order. This leads to unnecessary virt-handler, virt-controller and virt-api restarts.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

Change flags and restart virt-handlers, virt-controller and virt-api:

```

kind: InternalVirtualizationKubeVirt
...
spec:
  customizeComponents:
    flags:
      api:
        metrics-listen: 127.0.0.1
        metrics-port: "8080"
      controller:
        metrics-listen: 127.0.0.1
        metrics-port: "8080"
      handler:
        metrics-listen: 127.0.0.1
        metrics-port: "8080"
...

Let's juggle these flags ;)

# diff -u <(kubectl -n d8-virtualization rollout history ds/virt-handler --revision 357 -oyaml) <(kubectl -n d8-virtualization rollout history ds/virt-handler --revision 365 -oyaml)
--- /dev/fd/63	2025-09-10 16:48:30.749728663 +0300
+++ /dev/fd/62	2025-09-10 16:48:30.749728663 +0300
....
@@ -201,10 +201,10 @@
         - "2"
         command:
         - virt-handler
-        - --metrics-listen
-        - 127.0.0.1
         - --metrics-port
         - "8080"
+        - --metrics-listen
+        - 127.0.0.1


# diff -u <(kubectl -n d8-virtualization rollout history ds/virt-handler --revision 365 -oyaml) <(kubectl -n d8-virtualization rollout history ds/virt-handler --revision 366 -oyaml)
--- /dev/fd/63	2025-09-10 16:46:47.119034000 +0300
+++ /dev/fd/62	2025-09-10 16:46:47.119034000 +0300
@@ -201,10 +201,10 @@
         - "2"
         command:
         - virt-handler
-        - --metrics-port
-        - "8080"
         - --metrics-listen
         - 127.0.0.1
+        - --metrics-port
+        - "8080"
         env:
         - name: KUBECONFIG
           value: /kubeconfig.local/kube-api-rewriter.kubeconfig

```


After this PR:

No unnecessary restarts and flags order changes.


### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

