### PR TITLE
feat(metrics): add network label with network name

### DIFF
--- a/pkg/monitoring/metrics/virt-handler/domainstats/domainstats.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/domainstats.go
@@ -20,10 +20,12 @@
 package domainstats
 
 import (
+	"encoding/json"
 	"strings"
 
 	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
 	k6tv1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/log"
 
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/stats"
 )
@@ -40,6 +42,7 @@ type VirtualMachineInstanceReport struct {
 	vmi           *k6tv1.VirtualMachineInstance
 	vmiStats      *VirtualMachineInstanceStats
 	runtimeLabels map[string]string
+	networkNames  map[string]string
 }
 
 type VirtualMachineInstanceStats struct {
@@ -53,6 +56,9 @@ func newVirtualMachineInstanceReport(vmi *k6tv1.VirtualMachineInstance, vmiStats
 		vmiStats: vmiStats,
 	}
 	vmiReport.buildRuntimeLabels()
+
+	// Fill networkNames.
+	vmiReport.parseNetworkNames(vmi)
 
 	return vmiReport
 }
@@ -90,4 +96,41 @@ func (vmiReport *VirtualMachineInstanceReport) newCollectorResultWithLabels(metr
 		ConstLabels: vmiLabels,
 		Value:       value,
 	}
+}
+
+func (vmiReport *VirtualMachineInstanceReport) networkNameByIface(iface string) string {
+	if netName, ok := vmiReport.networkNames[iface]; ok {
+		return netName
+	}
+	return iface
+}
+
+type d8NetworkSpec struct {
+	Type   string `json:"type"`
+	Name   string `json:"name"`
+	IfName string `json:"ifName"`
+}
+
+// parseNetworkNames parse annotation with network specs and makes index interfaceName -> networkName.
+//
+// Annotation example:
+//
+//	network.deckhouse.io/networks-spec: '[{"type":"ClusterNetwork","name":"cnet1","ifName":"veth_cne8f3b5d3"},{"type":"ClusterNetwork","name":"cn-1003-for-e2e-test","ifName":"veth_cnce02ff17"}]'
+func (vmiReport *VirtualMachineInstanceReport) parseNetworkNames(vmi *k6tv1.VirtualMachineInstance) map[string]string {
+	networksSpecsRaw := vmi.GetAnnotations()["network.deckhouse.io/networks-spec"]
+	if networksSpecsRaw == "" {
+		return nil
+	}
+	var networksSpecs []d8NetworkSpec
+	err := json.Unmarshal([]byte(networksSpecsRaw), &networksSpecs)
+	if err != nil {
+		log.Log.Warningf("invalid d8 networks specs for network labels on VM %s: %v", vmi.Name, err)
+		return nil
+	}
+
+	specs := make(map[string]string)
+	for _, n := range networksSpecs {
+		specs[n.IfName] = n.Name
+	}
+	return specs
 }

--- a/pkg/monitoring/metrics/virt-handler/domainstats/domainstats.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/domainstats.go
@@ -119,6 +119,7 @@ type d8NetworkSpec struct {
 func (vmiReport *VirtualMachineInstanceReport) parseNetworkNames(vmi *k6tv1.VirtualMachineInstance) map[string]string {
 	networksSpecsRaw := vmi.GetAnnotations()["network.deckhouse.io/networks-spec"]
 	if networksSpecsRaw == "" {
+		log.Log.Warningf("no d8 networks specs: annotations=%+v on VM %s: %v", vmi.GetAnnotations(), vmi.Name)
 		return nil
 	}
 	var networksSpecs []d8NetworkSpec

--- a/pkg/monitoring/metrics/virt-handler/domainstats/network_metrics.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/network_metrics.go
@@ -119,6 +119,7 @@ func (networkMetrics) Collect(vmiReport *VirtualMachineInstanceReport) []operato
 			iface = net.Alias
 		}
 		netLabels := map[string]string{"interface": iface}
+		netLabels["network"] = vmiReport.networkNameByIface(iface)
 
 		if net.RxBytesSet {
 			deprecatedLabels := map[string]string{"interface": iface, "type": "rx"}

--- a/pkg/monitoring/metrics/virt-handler/domainstats/network_metrics_test.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/network_metrics_test.go
@@ -20,10 +20,9 @@
 package domainstats
 
 import (
+	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k6tv1 "kubevirt.io/api/core/v1"
 
@@ -36,6 +35,9 @@ var _ = Describe("network metrics", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-vmi-1",
 				Namespace: "test-ns-1",
+				Annotations: map[string]string{
+					"network.deckhouse.io/networks-spec": `[{"type":"Network","name":"test-1","ifName":"vnet0"}]`,
+				},
 			},
 		}
 
@@ -67,6 +69,11 @@ var _ = Describe("network metrics", func() {
 		}
 
 		vmiReport := newVirtualMachineInstanceReport(vmi, vmiStats)
+
+		It("should parse network names from annotation", func() {
+			Expect(vmiReport.networkNames).To(HaveKey("vnet0"))
+			Expect(vmiReport.networkNames["vnet0"]).To(Equal("test-1"))
+		})
 
 		DescribeTable("should collect metrics values", func(metric operatormetrics.Metric, expectedValue float64) {
 			crs := networkMetrics{}.Collect(vmiReport)

--- a/pkg/monitoring/metrics/virt-handler/domainstats/network_metrics_test.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/network_metrics_test.go
@@ -20,9 +20,10 @@
 package domainstats
 
 import (
-	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k6tv1 "kubevirt.io/api/core/v1"
 
@@ -71,8 +72,7 @@ var _ = Describe("network metrics", func() {
 		vmiReport := newVirtualMachineInstanceReport(vmi, vmiStats)
 
 		It("should parse network names from annotation", func() {
-			Expect(vmiReport.networkNames).To(HaveKey("vnet0"))
-			Expect(vmiReport.networkNames["vnet0"]).To(Equal("test-1"))
+			Expect(vmiReport.networkNameByIface("vnet0")).To(Equal("test-1"))
 		})
 
 		DescribeTable("should collect metrics values", func(metric operatormetrics.Metric, expectedValue float64) {


### PR DESCRIPTION
- Use "network.deckhouse.io/networks-spec" annotation to detect network name by the interface name.
- Add "network" label to network metrics.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

```
kubevirt_vmi_network_receive_bytes_total{interface="default",...,name="testvm",namespace="vms",node="node-0"} 90
kubevirt_vmi_network_receive_bytes_total{interface="veth_cnce02ff17",...,name="testmv",namespace="vms",node="node-0"} 90
kubevirt_vmi_network_receive_bytes_total{interface="veth_cne8f3b5d3",...,name="testvm",namespace="vms",node="node-0"} 90
```

#### After this PR:

Given this spec in VM:
```
spec:
  networks:
  - type: Main
  - name: cnet1
    type: ClusterNetwork
  - name: cn-1003-for-e2e-test
    type: ClusterNetwork
```

Metrics will be:

```
kubevirt_vmi_network_receive_bytes_total{interface="default",network="default",...,name="testvm",namespace="vms",node="node-0"} 90
kubevirt_vmi_network_receive_bytes_total{interface="veth_cnce02ff17",network="cnet1",...,name="testmv",namespace="vms",node="node-0"} 90
kubevirt_vmi_network_receive_bytes_total{interface="veth_cne8f3b5d3",network="cn-1003-for-e2e-test",...,name="testvm",namespace="vms",node="node-0"} 90
```

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

