### PR TITLE
fix(vm): fix a bug with a false restart requirement when removing a hotplug

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -2999,8 +2999,8 @@ func validLiveUpdateDisks(oldVMSpec *virtv1.VirtualMachineSpec, vm *virtv1.Virtu
 	}
 	// Evaluate if any disks were removed and they were hotplugged volumes
 	for _, d := range oldDisks {
-		v := oldVols[d.Name]
-		if !storagetypes.IsHotplugVolume(v) {
+		v, ok := oldVols[d.Name]
+		if ok && !storagetypes.IsHotplugVolume(v) {
 			return false
 		}
 	}


### PR DESCRIPTION
Fix a bug with a false restart requirement when removing a hotplug 

This fix will no longer be needed after upgrading to KubeVirt 1.6, where the issue is also resolved
