### PR TITLE
fix(vmbda): NFS hoplug

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1073,7 +1073,7 @@ func (t *templateService) RenderHotplugAttachmentPodTemplate(volumes []*v1.Volum
 			if !skipMount {
 				pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, k8sv1.VolumeMount{
 					Name:      volume.Name,
-					MountPath: fmt.Sprintf("/%s", volume.Name),
+					MountPath: fmt.Sprintf("/path/%s", volume.Name),
 				})
 			}
 		}

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -3995,7 +3995,7 @@ var _ = Describe("Template", func() {
 				},
 				{
 					Name:      volumeName,
-					MountPath: "/" + volumeName,
+					MountPath: "/path/" + volumeName,
 				},
 			}))
 		})

--- a/pkg/virt-handler/hotplug-disk/findmnt.go
+++ b/pkg/virt-handler/hotplug-disk/findmnt.go
@@ -66,7 +66,7 @@ func LookupFindmntInfoByVolume(volumeName string, pid int) ([]FindmntInfo, error
 
 	var result []FindmntInfo
 
-	mountPoint := path.Join("/", volumeName)
+	mountPoint := path.Join("/path", volumeName)
 	for _, mountInfo := range mounts {
 		if mountInfo.Mountpoint == mountPoint {
 			result = append(result, FindmntInfo{


### PR DESCRIPTION
## Description
That PR fix path placement for filesystem pvc.

## Why do we need it, and what problem does it solve?
Thats required for read-only containers and erofs(containerv2).
