### PR TITLE
feat(migration): add failed condition

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -1009,8 +1009,6 @@ func (c *VMController) addStartRequest(vm *virtv1.VirtualMachine) error {
 	}
 	vm.Status.StateChangeRequests = append(vm.Status.StateChangeRequests, addRequest[0])
 
-	fmt.Println("BBBB")
-	fmt.Println(vm.Status.StateChangeRequests)
 	return nil
 }
 

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -622,6 +622,19 @@ const (
 	// VirtualMachineInstanceMigrationAbortRequested indicates that live migration abort has been requested
 	VirtualMachineInstanceMigrationAbortRequested          VirtualMachineInstanceMigrationConditionType = "migrationAbortRequested"
 	VirtualMachineInstanceMigrationRejectedByResourceQuota VirtualMachineInstanceMigrationConditionType = "migrationRejectedByResourceQuota"
+	VirtualMachineInstanceMigrationFailed                  VirtualMachineInstanceMigrationConditionType = "migrationFailed"
+)
+
+const (
+	VirtualMachineInstanceMigrationFailedReasonVMIDoesNotExist                                    string = "VMIDoesNotExist"
+	VirtualMachineInstanceMigrationFailedReasonVMIIsShutdown                                      string = "VMIIsShutdown"
+	VirtualMachineInstanceMigrationFailedReasonTargetPodWasDeletedBecauseTimeoutExceeded          string = "TargetPodWasDeletedBecauseTimeoutExceeded"
+	VirtualMachineInstanceMigrationFailedReasonTargetPodShutdownDuringMigration                   string = "TargetPodShutdownDuringMigration"
+	VirtualMachineInstanceMigrationFailedReasonTargetPodDisappearedDuringMigration                string = "TargetPodDisappearedDuringMigration"
+	VirtualMachineInstanceMigrationFailedReasonMigrationStateClearedDuringMigration               string = "MigrationStateClearedDuringMigration"
+	VirtualMachineInstanceMigrationFailedReasonMigrationStateWasTakenOverByAnotherMigrationObject string = "MigrationStateWasTakenOverByAnotherMigrationObject"
+	VirtualMachineInstanceMigrationFailedReasonSourceNodeReportedMigrationFailed                  string = "SourceNodeReportedMigrationFailed"
+	VirtualMachineInstanceMigrationFailedReasonTargetAttachmentPodShutdownDuringMigration         string = "TargetAttachmentPodShutdownDuringMigration"
 )
 
 type VirtualMachineInstanceCondition struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Added the migrationFailed condition for VMIM containing extended information about the migration that ended with an error. It duplicates the warning events.