### PR TITLE
fix(core): scrap metrics

### DIFF
--- a/pkg/monitoring/metrics/virt-handler/domainstats/filesystem_metrics.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/filesystem_metrics.go
@@ -49,7 +49,14 @@ func (filesystemMetrics) Describe() []operatormetrics.Metric {
 func (filesystemMetrics) Collect(vmiReport *VirtualMachineInstanceReport) []operatormetrics.CollectorResult {
 	var crs []operatormetrics.CollectorResult
 
+	uniqDisks := make(map[string]struct{})
 	for _, fsStat := range vmiReport.vmiStats.FsStats.Items {
+		uniqKey := fsStat.DiskName + fsStat.MountPoint + fsStat.FileSystemType
+		if _, ok := uniqDisks[uniqKey]; ok {
+			continue
+		}
+		uniqDisks[uniqKey] = struct{}{}
+
 		fsLabels := map[string]string{
 			"disk_name":        fsStat.DiskName,
 			"mount_point":      fsStat.MountPoint,

--- a/pkg/monitoring/metrics/virt-handler/domainstats/filesystem_metrics_test.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/filesystem_metrics_test.go
@@ -67,4 +67,41 @@ var _ = Describe("filesystem metrics", func() {
 			Expect(crs).To(BeEmpty())
 		})
 	})
+	Context("on Collect with dublicates", func() {
+		It("should be contains only one metric", func() {
+			vmi := &k6tv1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vmi-1",
+					Namespace: "test-ns-1",
+				},
+			}
+
+			vmiStats := &VirtualMachineInstanceStats{
+				FsStats: k6tv1.VirtualMachineInstanceFileSystemList{
+					Items: []k6tv1.VirtualMachineInstanceFileSystem{
+						{
+							DiskName:       "test-disk-1",
+							MountPoint:     "/",
+							FileSystemType: "ext4",
+							TotalBytes:     1,
+							UsedBytes:      2,
+						},
+						{
+							DiskName:       "test-disk-1",
+							MountPoint:     "/",
+							FileSystemType: "ext4",
+							TotalBytes:     1,
+							UsedBytes:      2,
+						},
+					},
+				},
+			}
+
+			vmiReport := newVirtualMachineInstanceReport(vmi, vmiStats)
+
+			crs := filesystemMetrics{}.Collect(vmiReport)
+
+			Expect(crs).To(HaveLen(1))
+		})
+	})
 })


### PR DESCRIPTION
## Description
Fix bug that causes when CSI driver made multiple mount with --bind flag. In that case QEMU guest agent  return filesystem list with duplicates.


## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
