### PR TITLE
chore: fix nil map panic in node-labeller

### DIFF
--- a/pkg/virt-handler/node-labeller/node_labeller.go
+++ b/pkg/virt-handler/node-labeller/node_labeller.go
@@ -184,6 +184,10 @@ func (n *NodeLabeller) run() error {
 		return err
 	}
 
+	if originalNode == nil {
+		return fmt.Errorf("got empty node %s without API errors: check kube-apiserver logs for problems", n.host)
+	}
+
 	node := originalNode.DeepCopy()
 
 	if !skipNodeLabelling(node) {


### PR DESCRIPTION
API server may return empty node without API error if there are problem with interaction between kube-apiserver and etcd.

Rare situation, but worth to fix.


```
{"component":"virt-handler","level":"info","msg":"certificate with common name 'kubevirt.io:system:node:virt-handler' retrieved.","pos":"cert-manager.go:198","timestamp":"2025-10-03T14:56:10.904727Z"}
{"component":"virt-handler","level":"info","msg":"certificate with common name 'kubevirt.io:system:client:virt-handler' retrieved.","pos":"cert-manager.go:198","timestamp":"2025-10-03T14:56:10.905500Z"}
{"component":"virt-handler","level":"info","msg":"metrics: max concurrent requests=3","pos":"virt-handler.go:549","timestamp":"2025-10-03T14:56:10.905982Z"}
E1003 14:56:10.908996 1507964 runtime.go:79] Observed a panic: "assignment to entry in nil map" (assignment to entry in nil map)
goroutine 55 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x1ff1d60, 0x390d400})
	/kubevirt/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:75 +0x85
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc0003a7580?})
	/kubevirt/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:49 +0x65
panic({0x1ff1d60?, 0x390d400?})
	/usr/lib/golang/src/runtime/panic.go:792 +0x132
kubevirt.io/kubevirt/pkg/virt-handler/node-labeller.(*NodeLabeller).addLabellerLabels(...)
	/kubevirt/pkg/virt-handler/node-labeller/node_labeller.go:305
kubevirt.io/kubevirt/pkg/virt-handler/node-labeller.(*NodeLabeller).run(0xc0002ba280)
	/kubevirt/pkg/virt-handler/node-labeller/node_labeller.go:195 +0x594

```