### PR TITLE
feat: set provisioned size for PVC volumes in KubeVirt VMI status

### DIFF
--- a/pkg/host-disk/host-disk.go
+++ b/pkg/host-disk/host-disk.go
@@ -186,7 +186,7 @@ func createSparseRaw(fullPath string, size int64) (err error) {
 
 func createQcow2(fullPath string, size int64) (err error) {
 	log.Log.Infof("Create %s with qcow2 format", fullPath)
-	cmd := exec.Command("qemu-img", "create", "-f", "qcow2", fullPath, fmt.Sprintf("%db", size))
+	cmd := exec.Command("qemu-img", "create", "-f", "qcow2", "-o", "preallocation=falloc", fullPath, fmt.Sprintf("%db", size))
 	if err = cmd.Run(); err != nil {
 		return fmt.Errorf("failed to create qcow2: %w", err)
 	}

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -962,7 +962,7 @@ func configureLocalDiskToMigrate(dom *libvirtxml.Domain, vmi *v1.VirtualMachineI
 		if _, ok := blockSrcFsDstVols[name]; ok {
 			log.Log.V(2).Infof("Replace block source with destination for volume %s", name)
 			dom.Devices.Disks[i].Source.File = &libvirtxml.DomainDiskSourceFile{
-				File: hostdisk.GetMountedHostDiskDir(name),
+				File: filepath.Join(hostdisk.GetMountedHostDiskDir(name), "disk.img"),
 			}
 			dom.Devices.Disks[i].Source.Block = nil
 		}


### PR DESCRIPTION
This enhancement populates the `size` field within the `volumeStatus` of a VirtualMachineInstance (VMI) for Persistent Volume Claims (PVCs) by detecting the actual disk capacity at runtime.

**How it works:**
When a VMI starts, the system examines the block devices or filesystem mounts containing PVC volumes (including raw block devices and qcow2 images). Using `qemu-img info`, it retrieves the actual physical disk size and exposes this information directly in the VMI status.

