### PR TITLE
fix(vmi): more frequently poll for applied checksum

### DIFF
--- a/pkg/virt-handler/checksum-controller/checksum-controller.go
+++ b/pkg/virt-handler/checksum-controller/checksum-controller.go
@@ -63,7 +63,7 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 		for key := range c.objects {
 			c.queue.Add(key)
 		}
-	}, time.Minute, stopCh)
+	}, 5*time.Second, stopCh)
 
 	wait.Until(c.runWorker, time.Second, stopCh)
 }


### PR DESCRIPTION
There is no chance to detect checksum difference in 1 minute polling. Change period to 5 seconds to detect applied checksum from virt-launcher.
