### PR TITLE
fix: register default cgroup managers

### DIFF
--- a/cmd/virt-chroot/cgroup.go
+++ b/cmd/virt-chroot/cgroup.go
@@ -12,6 +12,9 @@ import (
 	runc_fs2 "github.com/opencontainers/runc/libcontainer/cgroups/fs2"
 	runc_configs "github.com/opencontainers/runc/libcontainer/configs"
 
+	// Import the cgroups/devices package to register the default cgroups managers.
+	_ "github.com/opencontainers/runc/libcontainer/cgroups/devices"
+
 	cgroupconsts "kubevirt.io/kubevirt/pkg/virt-handler/cgroup/constants"
 )
 


### PR DESCRIPTION
### What this PR does
Import the cgroups/devices package to register the default cgroups manager

It is needed after bumping github.com/opencontainers/runc from v1.1.4 to v1.2.8 in #42.
