### PR TITLE
backport: register default cgroup managers (#46)

### DIFF
--- a/cmd/virt-chroot/cgroup.go
+++ b/cmd/virt-chroot/cgroup.go
@@ -12,6 +12,9 @@ import (
 	runc_fs2 "github.com/opencontainers/runc/libcontainer/cgroups/fs2"
 	runc_configs "github.com/opencontainers/runc/libcontainer/configs"
 
+	// Import the cgroups/devices package to register the default cgroups managers.
+	_ "github.com/opencontainers/runc/libcontainer/cgroups/devices"
+
 	cgroupconsts "kubevirt.io/kubevirt/pkg/virt-handler/cgroup/constants"
 )
 


### PR DESCRIPTION
# Description
Backport register default cgroup managers (https://github.com/deckhouse/3p-kubevirt/pull/46)