### PR TITLE
fix(vm): use hostNetwork for hotplug pods to avoid IP consumption

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1027,8 +1027,6 @@ func (t *templateService) RenderHotplugAttachmentPodTemplate(volumes []*v1.Volum
 			},
 		},
 		Spec: k8sv1.PodSpec{
-			HostNetwork: true,
-			DNSPolicy:   k8sv1.DNSClusterFirstWithHostNet,
 			Containers: []k8sv1.Container{
 				{
 					Name:      hotplugDisk,
@@ -1082,6 +1080,8 @@ func (t *templateService) RenderHotplugAttachmentPodTemplate(volumes []*v1.Volum
 			Tolerations:                   tmpTolerations,
 			Volumes:                       []k8sv1.Volume{emptyDirVolume(hotplugDisks)},
 			TerminationGracePeriodSeconds: &zero,
+			HostNetwork:                   true,
+			DNSPolicy:                     k8sv1.DNSClusterFirstWithHostNet,
 		},
 	}
 	first := true
@@ -1205,8 +1205,6 @@ func (t *templateService) RenderHotplugAttachmentTriggerPodTemplate(volume *v1.V
 			Annotations: annotationsList,
 		},
 		Spec: k8sv1.PodSpec{
-			HostNetwork: true,
-			DNSPolicy:   k8sv1.DNSClusterFirstWithHostNet,
 			Containers: []k8sv1.Container{
 				{
 					Name:      hotplugDisk,
@@ -1263,6 +1261,8 @@ func (t *templateService) RenderHotplugAttachmentTriggerPodTemplate(volume *v1.V
 				emptyDirVolume(hotplugDisks),
 			},
 			TerminationGracePeriodSeconds: &zero,
+			HostNetwork:                   true,
+			DNSPolicy:                     k8sv1.DNSClusterFirstWithHostNet,
 		},
 	}
 

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1022,10 +1022,13 @@ func (t *templateService) RenderHotplugAttachmentPodTemplate(volumes []*v1.Volum
 				}),
 			},
 			Labels: map[string]string{
-				v1.AppLabel: hotplugDisk,
+				v1.AppLabel:                            hotplugDisk,
+				"security.deckhouse.io/skip-pss-check": "true",
 			},
 		},
 		Spec: k8sv1.PodSpec{
+			HostNetwork: true,
+			DNSPolicy:   k8sv1.DNSClusterFirstWithHostNet,
 			Containers: []k8sv1.Container{
 				{
 					Name:      hotplugDisk,
@@ -1196,11 +1199,14 @@ func (t *templateService) RenderHotplugAttachmentTriggerPodTemplate(volume *v1.V
 				}),
 			},
 			Labels: map[string]string{
-				v1.AppLabel: hotplugDisk,
+				v1.AppLabel:                            hotplugDisk,
+				"security.deckhouse.io/skip-pss-check": "true",
 			},
 			Annotations: annotationsList,
 		},
 		Spec: k8sv1.PodSpec{
+			HostNetwork: true,
+			DNSPolicy:   k8sv1.DNSClusterFirstWithHostNet,
 			Containers: []k8sv1.Container{
 				{
 					Name:      hotplugDisk,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
- Use hostNetwork: true for hotplug pods to avoid consuming IP addresses from the cluster IP pool
- Add DNSPolicy: ClusterFirstWithHostNet to preserve cluster DNS resolution
- Add security.deckhouse.io/skip-pss-check: true to comply with Gatekeeper policy

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

