### PR TITLE
feat(core): exclude hotplug pod from qouta accounting

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1022,8 +1022,9 @@ func (t *templateService) RenderHotplugAttachmentPodTemplate(volumes []*v1.Volum
 				}),
 			},
 			Labels: map[string]string{
-				v1.AppLabel:                            hotplugDisk,
-				"security.deckhouse.io/skip-pss-check": "true",
+				v1.AppLabel:                                    hotplugDisk,
+				"security.deckhouse.io/skip-pss-check":         "true",
+				"resource-quota-overrides.deckhouse.io/ignore": "true",
 			},
 		},
 		Spec: k8sv1.PodSpec{
@@ -1199,8 +1200,9 @@ func (t *templateService) RenderHotplugAttachmentTriggerPodTemplate(volume *v1.V
 				}),
 			},
 			Labels: map[string]string{
-				v1.AppLabel:                            hotplugDisk,
-				"security.deckhouse.io/skip-pss-check": "true",
+				v1.AppLabel:                                    hotplugDisk,
+				"security.deckhouse.io/skip-pss-check":         "true",
+				"resource-quota-overrides.deckhouse.io/ignore": "true",
 			},
 			Annotations: annotationsList,
 		},


### PR DESCRIPTION
## Description
Exclude hoplug pod from qouta calculations.

## Why do we need it, and what problem does it solve?
For transparent quota calculation and to exclude the influence of system resources on user quotas.


## What is the expected result?
Hotplug pod should be created with `resource-quota-overrides.deckhouse.io/ignore` label.