### PR TITLE
feat(core): virt-launcher quota exclude

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1022,9 +1022,9 @@ func (t *templateService) RenderHotplugAttachmentPodTemplate(volumes []*v1.Volum
 				}),
 			},
 			Labels: map[string]string{
-				v1.AppLabel:                                    hotplugDisk,
-				"security.deckhouse.io/skip-pss-check":         "true",
-				"resource-quota-overrides.deckhouse.io/ignore": "true",
+				v1.AppLabel:                            hotplugDisk,
+				"security.deckhouse.io/skip-pss-check": "true",
+				v1.ResourceQuotaExclusionLabel:          "true",
 			},
 		},
 		Spec: k8sv1.PodSpec{
@@ -1200,9 +1200,9 @@ func (t *templateService) RenderHotplugAttachmentTriggerPodTemplate(volume *v1.V
 				}),
 			},
 			Labels: map[string]string{
-				v1.AppLabel:                                    hotplugDisk,
-				"security.deckhouse.io/skip-pss-check":         "true",
-				"resource-quota-overrides.deckhouse.io/ignore": "true",
+				v1.AppLabel:                            hotplugDisk,
+				"security.deckhouse.io/skip-pss-check": "true",
+				v1.ResourceQuotaExclusionLabel:          "true",
 			},
 			Annotations: annotationsList,
 		},

--- a/pkg/virt-controller/watch/migration/migration.go
+++ b/pkg/virt-controller/watch/migration/migration.go
@@ -780,8 +780,6 @@ func (c *Controller) processMigrationPhase(
 			!vmiConditionManager.HasCondition(vmi, virtv1.VirtualMachineInstanceVCPUChange) &&
 			!vmiConditionManager.HasConditionWithStatus(vmi, virtv1.VirtualMachineInstanceMemoryChange, k8sv1.ConditionTrue) &&
 			!vmiConditionManager.HasConditionWithStatus(vmi, virtv1.VirtualMachineInstanceMigrationRequired, k8sv1.ConditionTrue) {
-			migrationCopy.Status.Phase = virtv1.MigrationSucceeded
-			c.recorder.Eventf(migration, k8sv1.EventTypeNormal, controller.SuccessfulMigrationReason, "Source node reported migration succeeded")
 
 			// Remove quota exclusion label from target pod after migration completion
 			if pod != nil && vmi.Status.MigrationState != nil && vmi.Status.MigrationState.TargetPod == pod.Name {
@@ -790,12 +788,15 @@ func (c *Controller) processMigrationPhase(
 					delete(podCopy.Labels, virtv1.ResourceQuotaExclusionLabel)
 					_, err := c.clientset.CoreV1().Pods(podCopy.Namespace).Update(context.Background(), podCopy, v1.UpdateOptions{})
 					if err != nil {
-						log.Log.Object(migration).Reason(err).Warning("Failed to remove quota exclusion label from target pod after migration completion")
+						return fmt.Errorf("failed to remove quota exclusion label from target pod after migration completion: %v", err)
 					} else {
-						log.Log.Object(migration).Info("Removed quota exclusion label from target pod after migration completion")
+						return fmt.Errorf("removed quota exclusion label from target pod after migration completion")
 					}
 				}
 			}
+
+			migrationCopy.Status.Phase = virtv1.MigrationSucceeded
+			c.recorder.Eventf(migration, k8sv1.EventTypeNormal, controller.SuccessfulMigrationReason, "Source node reported migration succeeded")
 		}
 	}
 	return nil

--- a/pkg/virt-controller/watch/migration/migration.go
+++ b/pkg/virt-controller/watch/migration/migration.go
@@ -782,6 +782,20 @@ func (c *Controller) processMigrationPhase(
 			!vmiConditionManager.HasConditionWithStatus(vmi, virtv1.VirtualMachineInstanceMigrationRequired, k8sv1.ConditionTrue) {
 			migrationCopy.Status.Phase = virtv1.MigrationSucceeded
 			c.recorder.Eventf(migration, k8sv1.EventTypeNormal, controller.SuccessfulMigrationReason, "Source node reported migration succeeded")
+
+			// Remove quota exclusion label from target pod after migration completion
+			if pod != nil && vmi.Status.MigrationState != nil && vmi.Status.MigrationState.TargetPod == pod.Name {
+				if _, exists := pod.Labels[virtv1.ResourceQuotaExclusionLabel]; exists {
+					podCopy := pod.DeepCopy()
+					delete(podCopy.Labels, virtv1.ResourceQuotaExclusionLabel)
+					_, err := c.clientset.CoreV1().Pods(podCopy.Namespace).Update(context.Background(), podCopy, v1.UpdateOptions{})
+					if err != nil {
+						log.Log.Object(migration).Reason(err).Warning("Failed to remove quota exclusion label from target pod after migration completion")
+					} else {
+						log.Log.Object(migration).Info("Removed quota exclusion label from target pod after migration completion")
+					}
+				}
+			}
 		}
 	}
 	return nil
@@ -891,6 +905,7 @@ func (c *Controller) createTargetPod(migration *virtv1.VirtualMachineInstanceMig
 	maps.Copy(nodeSelector, templatePod.Spec.NodeSelector)
 	templatePod.Spec.NodeSelector = nodeSelector
 
+	templatePod.ObjectMeta.Labels[virtv1.ResourceQuotaExclusionLabel] = "true"
 	templatePod.ObjectMeta.Labels[virtv1.MigrationJobLabel] = string(migration.UID)
 	templatePod.ObjectMeta.Annotations[virtv1.MigrationJobNameAnnotation] = migration.Name
 

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -1149,6 +1149,9 @@ const (
 	// Absence of the label means the lowest priority (pod with a network priority label is more prioritized than a pod without a label).
 	// The lower the numerical value, the higher the priority.
 	NetworkPriorityLabel string = "network.deckhouse.io/pod-common-ip-priority"
+	// A special label that excludes the pod from resource quota calculations.
+	// Used during migration to allow target pod creation without quota restrictions.
+	ResourceQuotaExclusionLabel string = "resource-quota-overrides.deckhouse.io/ignore"
 	// A special annotation through which information is passed from virt-launcher to virt-handler indicating
 	// that the virtual machine has been suspended for offline migration.
 	VirtualMachineSuspendedMigratedAnnotation string = "kubevirt.io/vm-suspended-migrated"


### PR DESCRIPTION
## Description
Add qouta exclude labels for virt-launcher pods. Thats required for exclude vm overhead  from quota.

## Why do we need it, and what problem does it solve?
Do not take vm overhead into quota accounting.

## What is the expected result?
Virt-launcher pod should has labels for qouta discound, also target pod should be excluded from accounting during migration.