### PR TITLE
chore: add heritage=deckhouse label for Pods in user ns

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1023,7 +1023,7 @@ func (t *templateService) RenderHotplugAttachmentPodTemplate(volumes []*v1.Volum
 			},
 			Labels: map[string]string{
 				v1.AppLabel:                            hotplugDisk,
-				v1.HeritageLabel:                       v1.HeritageDeckhouse,
+				v1.HeritageLabel:                       v1.HeritageValue,
 				"security.deckhouse.io/skip-pss-check": "true",
 				v1.ResourceQuotaExclusionLabel:         "true",
 			},
@@ -1202,7 +1202,7 @@ func (t *templateService) RenderHotplugAttachmentTriggerPodTemplate(volume *v1.V
 			},
 			Labels: map[string]string{
 				v1.AppLabel:                            hotplugDisk,
-				v1.HeritageLabel:                       v1.HeritageDeckhouse,
+				v1.HeritageLabel:                       v1.HeritageValue,
 				"security.deckhouse.io/skip-pss-check": "true",
 				v1.ResourceQuotaExclusionLabel:         "true",
 			},
@@ -1711,7 +1711,7 @@ func podLabels(vmi *v1.VirtualMachineInstance, hostName string) map[string]strin
 	labels[v1.AppLabel] = "virt-launcher"
 	labels[v1.CreatedByLabel] = string(vmi.UID)
 	labels[v1.VirtualMachineNameLabel] = hostName
-	labels[v1.HeritageLabel] = v1.HeritageDeckhouse
+	labels[v1.HeritageLabel] = v1.HeritageValue
 	return labels
 }
 

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1022,9 +1022,9 @@ func (t *templateService) RenderHotplugAttachmentPodTemplate(volumes []*v1.Volum
 				}),
 			},
 			Labels: map[string]string{
-				v1.AppLabel:                            hotplugDisk,
+				v1.AppLabel:                                    hotplugDisk,
 				"heritage":                             "deckhouse",
-				"security.deckhouse.io/skip-pss-check": "true",
+				"security.deckhouse.io/skip-pss-check":         "true",
 				v1.ResourceQuotaExclusionLabel:          "true",
 			},
 		},
@@ -1201,9 +1201,9 @@ func (t *templateService) RenderHotplugAttachmentTriggerPodTemplate(volume *v1.V
 				}),
 			},
 			Labels: map[string]string{
-				v1.AppLabel:                            hotplugDisk,
+				v1.AppLabel:                                    hotplugDisk,
 				"heritage":                             "deckhouse",
-				"security.deckhouse.io/skip-pss-check": "true",
+				"security.deckhouse.io/skip-pss-check":         "true",
 				v1.ResourceQuotaExclusionLabel:          "true",
 			},
 			Annotations: annotationsList,

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1023,6 +1023,7 @@ func (t *templateService) RenderHotplugAttachmentPodTemplate(volumes []*v1.Volum
 			},
 			Labels: map[string]string{
 				v1.AppLabel:                            hotplugDisk,
+				"heritage":                             "deckhouse",
 				"security.deckhouse.io/skip-pss-check": "true",
 				v1.ResourceQuotaExclusionLabel:          "true",
 			},
@@ -1201,6 +1202,7 @@ func (t *templateService) RenderHotplugAttachmentTriggerPodTemplate(volume *v1.V
 			},
 			Labels: map[string]string{
 				v1.AppLabel:                            hotplugDisk,
+				"heritage":                             "deckhouse",
 				"security.deckhouse.io/skip-pss-check": "true",
 				v1.ResourceQuotaExclusionLabel:          "true",
 			},
@@ -1709,6 +1711,7 @@ func podLabels(vmi *v1.VirtualMachineInstance, hostName string) map[string]strin
 	labels[v1.AppLabel] = "virt-launcher"
 	labels[v1.CreatedByLabel] = string(vmi.UID)
 	labels[v1.VirtualMachineNameLabel] = hostName
+	labels["heritage"] = "deckhouse"
 	return labels
 }
 

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1022,10 +1022,10 @@ func (t *templateService) RenderHotplugAttachmentPodTemplate(volumes []*v1.Volum
 				}),
 			},
 			Labels: map[string]string{
-				v1.AppLabel:                                    hotplugDisk,
-				"heritage":                             "deckhouse",
-				"security.deckhouse.io/skip-pss-check":         "true",
-				v1.ResourceQuotaExclusionLabel:          "true",
+				v1.AppLabel:                            hotplugDisk,
+				v1.HeritageLabel:                       v1.HeritageDeckhouse,
+				"security.deckhouse.io/skip-pss-check": "true",
+				v1.ResourceQuotaExclusionLabel:         "true",
 			},
 		},
 		Spec: k8sv1.PodSpec{
@@ -1201,10 +1201,10 @@ func (t *templateService) RenderHotplugAttachmentTriggerPodTemplate(volume *v1.V
 				}),
 			},
 			Labels: map[string]string{
-				v1.AppLabel:                                    hotplugDisk,
-				"heritage":                             "deckhouse",
-				"security.deckhouse.io/skip-pss-check":         "true",
-				v1.ResourceQuotaExclusionLabel:          "true",
+				v1.AppLabel:                            hotplugDisk,
+				v1.HeritageLabel:                       v1.HeritageDeckhouse,
+				"security.deckhouse.io/skip-pss-check": "true",
+				v1.ResourceQuotaExclusionLabel:         "true",
 			},
 			Annotations: annotationsList,
 		},
@@ -1711,7 +1711,7 @@ func podLabels(vmi *v1.VirtualMachineInstance, hostName string) map[string]strin
 	labels[v1.AppLabel] = "virt-launcher"
 	labels[v1.CreatedByLabel] = string(vmi.UID)
 	labels[v1.VirtualMachineNameLabel] = hostName
-	labels["heritage"] = "deckhouse"
+	labels[v1.HeritageLabel] = v1.HeritageDeckhouse
 	return labels
 }
 

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -463,7 +463,7 @@ var _ = Describe("Template", func() {
 					v1.AppLabel:                "virt-launcher",
 					v1.CreatedByLabel:          "1234",
 					v1.VirtualMachineNameLabel: "testvmi",
-					v1.HeritageLabel:           v1.HeritageDeckhouse,
+					v1.HeritageLabel:           v1.HeritageValue,
 				}))
 				Expect(pod.ObjectMeta.Annotations).To(Equal(map[string]string{
 					v1.DomainAnnotation:                                  "testvmi",
@@ -1059,7 +1059,7 @@ var _ = Describe("Template", func() {
 					v1.AppLabel:                "virt-launcher",
 					v1.CreatedByLabel:          "1234",
 					v1.VirtualMachineNameLabel: "testvmi",
-					v1.HeritageLabel:           v1.HeritageDeckhouse,
+					v1.HeritageLabel:           v1.HeritageValue,
 				}))
 				Expect(pod.ObjectMeta.GenerateName).To(Equal("virt-launcher-testvmi-"))
 				Expect(pod.Spec.NodeSelector).To(Equal(map[string]string{
@@ -1881,7 +1881,7 @@ var _ = Describe("Template", func() {
 						v1.AppLabel:                "virt-launcher",
 						v1.CreatedByLabel:          "1234",
 						v1.VirtualMachineNameLabel: "testvmi",
-						v1.HeritageLabel:           v1.HeritageDeckhouse,
+						v1.HeritageLabel:           v1.HeritageValue,
 					},
 				))
 			})

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -463,7 +463,7 @@ var _ = Describe("Template", func() {
 					v1.AppLabel:                "virt-launcher",
 					v1.CreatedByLabel:          "1234",
 					v1.VirtualMachineNameLabel: "testvmi",
-					"heritage":                 "deckhouse",
+					v1.HeritageLabel:           v1.HeritageDeckhouse,
 				}))
 				Expect(pod.ObjectMeta.Annotations).To(Equal(map[string]string{
 					v1.DomainAnnotation:                                  "testvmi",
@@ -1059,7 +1059,7 @@ var _ = Describe("Template", func() {
 					v1.AppLabel:                "virt-launcher",
 					v1.CreatedByLabel:          "1234",
 					v1.VirtualMachineNameLabel: "testvmi",
-					"heritage":                 "deckhouse",
+					v1.HeritageLabel:           v1.HeritageDeckhouse,
 				}))
 				Expect(pod.ObjectMeta.GenerateName).To(Equal("virt-launcher-testvmi-"))
 				Expect(pod.Spec.NodeSelector).To(Equal(map[string]string{
@@ -1881,7 +1881,7 @@ var _ = Describe("Template", func() {
 						v1.AppLabel:                "virt-launcher",
 						v1.CreatedByLabel:          "1234",
 						v1.VirtualMachineNameLabel: "testvmi",
-						"heritage":                 "deckhouse",
+						v1.HeritageLabel:           v1.HeritageDeckhouse,
 					},
 				))
 			})

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -463,6 +463,7 @@ var _ = Describe("Template", func() {
 					v1.AppLabel:                "virt-launcher",
 					v1.CreatedByLabel:          "1234",
 					v1.VirtualMachineNameLabel: "testvmi",
+					"heritage":                 "deckhouse",
 				}))
 				Expect(pod.ObjectMeta.Annotations).To(Equal(map[string]string{
 					v1.DomainAnnotation:                                  "testvmi",
@@ -1058,6 +1059,7 @@ var _ = Describe("Template", func() {
 					v1.AppLabel:                "virt-launcher",
 					v1.CreatedByLabel:          "1234",
 					v1.VirtualMachineNameLabel: "testvmi",
+					"heritage":                 "deckhouse",
 				}))
 				Expect(pod.ObjectMeta.GenerateName).To(Equal("virt-launcher-testvmi-"))
 				Expect(pod.Spec.NodeSelector).To(Equal(map[string]string{
@@ -1879,6 +1881,7 @@ var _ = Describe("Template", func() {
 						v1.AppLabel:                "virt-launcher",
 						v1.CreatedByLabel:          "1234",
 						v1.VirtualMachineNameLabel: "testvmi",
+						"heritage":                 "deckhouse",
 					},
 				))
 			})

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -1154,8 +1154,8 @@ const (
 	ResourceQuotaExclusionLabel string = "resource-quota-overrides.deckhouse.io/ignore"
 	// A special label that apply deckhouse policies on system Pods in user namespaces:
 	// forbid deletion, exec, connect for non-system users.
-	HeritageLabel     string = "heritage"
-	HeritageDeckhouse string = "deckhouse"
+	HeritageLabel string = "heritage"
+	HeritageValue string = "deckhouse"
 	// A special annotation through which information is passed from virt-launcher to virt-handler indicating
 	// that the virtual machine has been suspended for offline migration.
 	VirtualMachineSuspendedMigratedAnnotation string = "kubevirt.io/vm-suspended-migrated"

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -1152,6 +1152,10 @@ const (
 	// A special label that excludes the pod from resource quota calculations.
 	// Used during migration to allow target pod creation without quota restrictions.
 	ResourceQuotaExclusionLabel string = "resource-quota-overrides.deckhouse.io/ignore"
+	// A special label that apply deckhouse policies on system Pods in user namespaces:
+	// forbid deletion, exec, connect for non-system users.
+	HeritageLabel     string = "heritage"
+	HeritageDeckhouse string = "deckhouse"
 	// A special annotation through which information is passed from virt-launcher to virt-handler indicating
 	// that the virtual machine has been suspended for offline migration.
 	VirtualMachineSuspendedMigratedAnnotation string = "kubevirt.io/vm-suspended-migrated"


### PR DESCRIPTION
Support security hardening for Deckhouse system components implemented by https://github.com/deckhouse/deckhouse/pull/16749

Add heritage=deckhouse to Pods that run in user namespaces:

- virt-launcher Pods
- hp-volume Pods

