### PR TITLE
fix: add memory overhead to handle hotplug disks migration

### DIFF
--- a/pkg/virt-controller/services/renderresources.go
+++ b/pkg/virt-controller/services/renderresources.go
@@ -521,9 +521,9 @@ func GetMemoryOverhead(vmi *v1.VirtualMachineInstance, cpuArch string, additiona
 //
 // This includes the memory needed temporarily to perform
 // certain operations:
-// - VM migration with hotplugged disks.
+// - VM migration with disks.
 //
-// The return value is overhead memory quantity
+// The return value is an overhead memory quantity for memory limits.
 //
 // Note: This is the best estimation based on experiments
 // and may not be 100% accurate.

--- a/pkg/virt-controller/services/renderresources.go
+++ b/pkg/virt-controller/services/renderresources.go
@@ -275,6 +275,15 @@ func WithMemoryOverhead(guestResourceSpec v1.ResourceRequirements, memoryOverhea
 	}
 }
 
+func WithMemoryLimitsOverhead(memoryLimitsOverhead resource.Quantity) ResourceRendererOption {
+	return func(renderer *ResourceRenderer) {
+		if memoryLimit, ok := renderer.vmLimits[k8sv1.ResourceMemory]; ok {
+			memoryLimit.Add(memoryLimitsOverhead)
+			renderer.vmLimits[k8sv1.ResourceMemory] = memoryLimit
+		}
+	}
+}
+
 func WithAutoMemoryLimits(namespace string, namespaceStore cache.Store) ResourceRendererOption {
 	return func(renderer *ResourceRenderer) {
 		requestRatio := getMemoryLimitsRatio(namespace, namespaceStore)
@@ -490,7 +499,7 @@ func GetMemoryOverhead(vmi *v1.VirtualMachineInstance, cpuArch string, additiona
 	}
 
 	// Overhead to handle hotplug disks. ~60Mi should be enough for target Pod to survive migration.
-	addHotplugDisksOverheads(vmi, &overhead)
+	addHotplugDisksOverheads(vmi, &overhead, nil)
 
 	// Multiplying the ratio is expected to be the last calculation before returning overhead
 	if additionalOverheadRatio != nil && *additionalOverheadRatio != "" {
@@ -503,6 +512,26 @@ func GetMemoryOverhead(vmi *v1.VirtualMachineInstance, cpuArch string, additiona
 
 		overhead = multiplyMemory(overhead, ratio)
 	}
+
+	return overhead
+}
+
+// GetMemoryLimitsOverhead computes the estimation of additional
+// memory limit needed for the domain to operate properly.
+//
+// This includes the memory needed temporarily to perform
+// certain operations:
+// - VM migration with hotplugged disks.
+//
+// The return value is overhead memory quantity
+//
+// Note: This is the best estimation based on experiments
+// and may not be 100% accurate.
+func GetMemoryLimitsOverhead(vmi *v1.VirtualMachineInstance) resource.Quantity {
+	overhead := *resource.NewScaledQuantity(0, resource.Kilo)
+
+	// Add hotplug overhead for memory limits.
+	addHotplugDisksOverheads(vmi, nil, &overhead)
 
 	return overhead
 }

--- a/pkg/virt-controller/services/renderresources.go
+++ b/pkg/virt-controller/services/renderresources.go
@@ -489,6 +489,9 @@ func GetMemoryOverhead(vmi *v1.VirtualMachineInstance, cpuArch string, additiona
 		overhead.Add(resource.MustParse("100Mi"))
 	}
 
+	// Overhead to handle hotplug disks. ~60Mi should be enough for target Pod to survive migration.
+	addHotplugDisksOverheads(vmi, &overhead)
+
 	// Multiplying the ratio is expected to be the last calculation before returning overhead
 	if additionalOverheadRatio != nil && *additionalOverheadRatio != "" {
 		ratio, err := strconv.ParseFloat(*additionalOverheadRatio, 64)

--- a/pkg/virt-controller/services/renderresources.go
+++ b/pkg/virt-controller/services/renderresources.go
@@ -498,8 +498,8 @@ func GetMemoryOverhead(vmi *v1.VirtualMachineInstance, cpuArch string, additiona
 		overhead.Add(resource.MustParse("100Mi"))
 	}
 
-	// Overhead to handle hotplug disks. ~60Mi should be enough for target Pod to survive migration.
-	addHotplugDisksOverheads(vmi, &overhead, nil)
+	// Overhead to handle disks. ~60Mi should be enough for target Pod to survive migration.
+	addDisksOverheads(vmi, &overhead, nil)
 
 	// Multiplying the ratio is expected to be the last calculation before returning overhead
 	if additionalOverheadRatio != nil && *additionalOverheadRatio != "" {
@@ -530,8 +530,8 @@ func GetMemoryOverhead(vmi *v1.VirtualMachineInstance, cpuArch string, additiona
 func GetMemoryLimitsOverhead(vmi *v1.VirtualMachineInstance) resource.Quantity {
 	overhead := *resource.NewScaledQuantity(0, resource.Kilo)
 
-	// Add hotplug overhead for memory limits.
-	addHotplugDisksOverheads(vmi, nil, &overhead)
+	// Add disks overhead for memory limits.
+	addDisksOverheads(vmi, nil, &overhead)
 
 	return overhead
 }

--- a/pkg/virt-controller/services/renderresources_test.go
+++ b/pkg/virt-controller/services/renderresources_test.go
@@ -575,6 +575,7 @@ var _ = Describe("GetMemoryOverhead calculation", func() {
 		downwardmetricsOverhead *resource.Quantity
 		sevOverhead             *resource.Quantity
 		tpmOverhead             *resource.Quantity
+		disksOverhead           *resource.Quantity
 	)
 
 	BeforeEach(func() {
@@ -601,6 +602,7 @@ var _ = Describe("GetMemoryOverhead calculation", func() {
 		downwardmetricsOverhead = pointer.P(resource.MustParse("1Mi"))
 		sevOverhead = pointer.P(resource.MustParse("256Mi"))
 		tpmOverhead = pointer.P(resource.MustParse("53Mi"))
+		disksOverhead = pointer.P(resource.MustParse("60Mi"))
 	})
 
 	When("the vmi is not requesting any specific device or cpu or whatever", func() {
@@ -611,6 +613,7 @@ var _ = Describe("GetMemoryOverhead calculation", func() {
 			expected.Add(*videoRAMOverhead)
 			// 8Mi*1core(default)
 			expected.Add(*coresOverhead)
+			expected.Add(*disksOverhead)
 			overhead := GetMemoryOverhead(vmi, "amd64", nil)
 			Expect(overhead.Value()).To(BeEquivalentTo(expected.Value()))
 		})
@@ -630,6 +633,7 @@ var _ = Describe("GetMemoryOverhead calculation", func() {
 			expected.Add(*baseOverhead)
 			expected.Add(*staticOverhead)
 			expected.Add(*videoRAMOverhead)
+			expected.Add(*disksOverhead)
 			// (2cores* 2threads *2sockets)
 			value := coresOverhead.Value() * 8
 			expected.Add(*resource.NewQuantity(value, coresOverhead.Format))
@@ -670,6 +674,7 @@ var _ = Describe("GetMemoryOverhead calculation", func() {
 			expected.Add(*baseOverhead)
 			expected.Add(*staticOverhead)
 			expected.Add(*coresOverhead)
+			expected.Add(*disksOverhead)
 			overhead := GetMemoryOverhead(vmi, "amd64", nil)
 			Expect(overhead.Value()).To(BeEquivalentTo(expected.Value()))
 		})
@@ -683,6 +688,7 @@ var _ = Describe("GetMemoryOverhead calculation", func() {
 			expected.Add(*videoRAMOverhead)
 			expected.Add(*coresOverhead)
 			expected.Add(*cpuArchOverhead)
+			expected.Add(*disksOverhead)
 			overhead := GetMemoryOverhead(vmi, "arm64", nil)
 			Expect(overhead.Value()).To(BeEquivalentTo(expected.Value()))
 		})
@@ -697,6 +703,7 @@ var _ = Describe("GetMemoryOverhead calculation", func() {
 			expected.Add(*videoRAMOverhead)
 			expected.Add(*coresOverhead)
 			expected.Add(*vfioOverhead)
+			expected.Add(*disksOverhead)
 			overhead := GetMemoryOverhead(vmi, "amd64", nil)
 			Expect(overhead.Value()).To(BeEquivalentTo(expected.Value()))
 		},
@@ -717,6 +724,7 @@ var _ = Describe("GetMemoryOverhead calculation", func() {
 			expected.Add(*videoRAMOverhead)
 			expected.Add(*coresOverhead)
 			expected.Add(*downwardmetricsOverhead)
+			expected.Add(*disksOverhead)
 			overhead := GetMemoryOverhead(vmi, "amd64", nil)
 			Expect(overhead.Value()).To(BeEquivalentTo(expected.Value()))
 		})
@@ -732,6 +740,7 @@ var _ = Describe("GetMemoryOverhead calculation", func() {
 			expected.Add(*videoRAMOverhead)
 			expected.Add(*coresOverhead)
 			expected.Add(probeOverhead)
+			expected.Add(*disksOverhead)
 
 			overhead := GetMemoryOverhead(vmi, "amd64", nil)
 			Expect(overhead.Value()).To(BeEquivalentTo(expected.Value()))
@@ -756,6 +765,7 @@ var _ = Describe("GetMemoryOverhead calculation", func() {
 			expected.Add(*videoRAMOverhead)
 			expected.Add(*coresOverhead)
 			expected.Add(*sevOverhead)
+			expected.Add(*disksOverhead)
 			overhead := GetMemoryOverhead(vmi, "amd64", nil)
 			Expect(overhead.Value()).To(BeEquivalentTo(expected.Value()))
 		})
@@ -775,6 +785,7 @@ var _ = Describe("GetMemoryOverhead calculation", func() {
 			expected.Add(*videoRAMOverhead)
 			expected.Add(*coresOverhead)
 			expected.Add(*tpmOverhead)
+			expected.Add(*disksOverhead)
 			overhead := GetMemoryOverhead(vmi, "amd64", nil)
 			Expect(overhead.Value()).To(BeEquivalentTo(expected.Value()))
 		})
@@ -787,6 +798,7 @@ var _ = Describe("GetMemoryOverhead calculation", func() {
 			base.Add(*staticOverhead)
 			base.Add(*videoRAMOverhead)
 			base.Add(*coresOverhead)
+			base.Add(*disksOverhead)
 			var expected resource.Quantity
 			if expectParseError {
 				expected = *base
@@ -820,6 +832,7 @@ var _ = Describe("GetMemoryOverhead calculation", func() {
 			expected.Add(*staticOverhead)
 			expected.Add(*videoRAMOverhead)
 			expected.Add(*coresOverhead)
+			expected.Add(*disksOverhead)
 			expected.Add(resource.MustParse("100Mi"))
 
 			overhead := GetMemoryOverhead(vmi, "amd64", nil)

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1374,28 +1374,46 @@ func addProbeOverheads(vmi *v1.VirtualMachineInstance, quantity *resource.Quanti
 	}
 }
 
-func addHotplugDisksOverheads(vmi *v1.VirtualMachineInstance, quantity *resource.Quantity) {
-	// We need to add this overhead due to potential OOMKill during
-	// migration with hotplugged disks.
-	hasHotplugs := false
+// addHotplugDisksOverheads returns additional memory requests and limits needed to
+// overcome potential OOMKill during VM migration with hotplugged disks .
+func addHotplugDisksOverheads(vmi *v1.VirtualMachineInstance, overallOverhead *resource.Quantity, limitOnlyOverhead *resource.Quantity) {
+	hasHotplugDisks := false
 	for _, volume := range vmi.Spec.Volumes {
 		if volume.PersistentVolumeClaim != nil && volume.PersistentVolumeClaim.Hotpluggable {
-			hasHotplugs = true
+			hasHotplugDisks = true
 			break
 		}
 		if volume.ContainerDisk != nil && volume.ContainerDisk.Hotpluggable {
-			hasHotplugs = true
+			hasHotplugDisks = true
 			break
 		}
 		if volume.DataVolume != nil && volume.DataVolume.Hotpluggable {
-			hasHotplugs = true
+			hasHotplugDisks = true
 			break
 		}
 	}
 
-	if hasHotplugs {
-		hotplugOverhead := resource.MustParse("60Mi")
-		quantity.Add(hotplugOverhead)
+	// No disks, no changes.
+	if !hasHotplugDisks {
+		return
+	}
+
+	overheadValue := resource.MustParse("60Mi")
+
+	reqCPU := vmi.Spec.Domain.Resources.Requests.Cpu()
+	limitCPU := vmi.Spec.Domain.Resources.Limits.Cpu()
+	if reqCPU != nil && limitCPU != nil {
+		if reqCPU.Cmp(*limitCPU) == 0 {
+			// Add overhead for requests and limits for the domain with guaranteed CPU cores.
+			if overallOverhead != nil {
+				overallOverhead.Add(overheadValue)
+			}
+		} else {
+			// Add overhead only for limits if CPU cores are not guaranteed: domain CPU requests are not equal to limits.
+			if limitOnlyOverhead != nil {
+				limitOnlyOverhead.Add(overheadValue)
+			}
+		}
 	}
 }
 
@@ -1652,6 +1670,7 @@ func (t *templateService) VMIResourcePredicates(vmi *v1.VirtualMachineInstance, 
 		vmiCPUArch = t.clusterConfig.GetClusterCPUArch()
 	}
 	memoryOverhead := GetMemoryOverhead(vmi, vmiCPUArch, t.clusterConfig.GetConfig().AdditionalGuestMemoryOverheadRatio)
+	memoryLimitsOverhead := GetMemoryLimitsOverhead(vmi)
 
 	if t.netBindingPluginMemoryCalculator != nil {
 		memoryOverhead.Add(
@@ -1679,6 +1698,9 @@ func (t *templateService) VMIResourcePredicates(vmi *v1.VirtualMachineInstance, 
 			NewVMIResourceRule(not(doesVMIRequireDedicatedCPU), WithoutDedicatedCPU(vmi, t.clusterConfig.GetCPUAllocationRatio(), withCPULimits)),
 			NewVMIResourceRule(hasHugePages, WithHugePages(vmi.Spec.Domain.Memory, memoryOverhead)),
 			NewVMIResourceRule(not(hasHugePages), WithMemoryOverhead(vmi.Spec.Domain.Resources, memoryOverhead)),
+			NewVMIResourceRule(func(_ *v1.VirtualMachineInstance) bool {
+				return memoryLimitsOverhead.Value() > 0
+			}, WithMemoryLimitsOverhead(memoryLimitsOverhead)),
 			NewVMIResourceRule(t.doesVMIRequireAutoMemoryLimits, WithAutoMemoryLimits(vmi.Namespace, t.namespaceStore)),
 			NewVMIResourceRule(func(*v1.VirtualMachineInstance) bool {
 				return len(networkToResourceMap) > 0

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1377,6 +1377,13 @@ func addProbeOverheads(vmi *v1.VirtualMachineInstance, quantity *resource.Quanti
 // addDisksOverheads returns additional memory requests and limits needed to
 // overcome potential OOMKill during VM migration.
 func addDisksOverheads(vmi *v1.VirtualMachineInstance, overallOverhead *resource.Quantity, limitOnlyOverhead *resource.Quantity) {
+	// No overhead if hotplug disks are disabled and no directly attached disks.
+	noHotplug := vmi.Spec.Domain.Devices.DisableHotplug
+	noDisks := len(vmi.Spec.Domain.Devices.Disks) == 0
+	if noHotplug && noDisks {
+		return
+	}
+
 	overheadValue := resource.MustParse("60Mi")
 
 	reqCPU := vmi.Spec.Domain.Resources.Requests.Cpu()

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -393,11 +393,14 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 		})
 	}
 
+	// ImageIDs are passed when render target launch manifest for migration.
+	isMigrationTarget := imageIDs != nil
+
 	networkToResourceMap, err := multus.NetworkToResource(t.virtClient, vmi)
 	if err != nil {
 		return nil, err
 	}
-	resourceRenderer, err := t.newResourceRenderer(vmi, networkToResourceMap)
+	resourceRenderer, err := t.newResourceRenderer(vmi, networkToResourceMap, isMigrationTarget)
 	if err != nil {
 		return nil, err
 	}
@@ -906,7 +909,7 @@ func (t *templateService) newVolumeRenderer(vmi *v1.VirtualMachineInstance, name
 	return volumeRenderer, nil
 }
 
-func (t *templateService) newResourceRenderer(vmi *v1.VirtualMachineInstance, networkToResourceMap map[string]string) (*ResourceRenderer, error) {
+func (t *templateService) newResourceRenderer(vmi *v1.VirtualMachineInstance, networkToResourceMap map[string]string, isMigrationTarget bool) (*ResourceRenderer, error) {
 	vmiResources := vmi.Spec.Domain.Resources
 	baseOptions := []ResourceRendererOption{
 		WithEphemeralStorageRequest(),
@@ -917,7 +920,7 @@ func (t *templateService) newResourceRenderer(vmi *v1.VirtualMachineInstance, ne
 		return nil, err
 	}
 
-	options := append(baseOptions, t.VMIResourcePredicates(vmi, networkToResourceMap).Apply()...)
+	options := append(baseOptions, t.VMIResourcePredicates(vmi, networkToResourceMap, isMigrationTarget).Apply()...)
 	return NewResourceRenderer(vmiResources.Limits, vmiResources.Requests, options...), nil
 }
 
@@ -1663,7 +1666,7 @@ func (t *templateService) doesVMIRequireAutoCPULimits(vmi *v1.VirtualMachineInst
 	return false
 }
 
-func (t *templateService) VMIResourcePredicates(vmi *v1.VirtualMachineInstance, networkToResourceMap map[string]string) VMIResourcePredicates {
+func (t *templateService) VMIResourcePredicates(vmi *v1.VirtualMachineInstance, networkToResourceMap map[string]string, isMigrationTarget bool) VMIResourcePredicates {
 	// Set default with vmi Architecture. compatible with multi-architecture hybrid environments
 	vmiCPUArch := vmi.Spec.Architecture
 	if vmiCPUArch == "" {
@@ -1699,7 +1702,7 @@ func (t *templateService) VMIResourcePredicates(vmi *v1.VirtualMachineInstance, 
 			NewVMIResourceRule(hasHugePages, WithHugePages(vmi.Spec.Domain.Memory, memoryOverhead)),
 			NewVMIResourceRule(not(hasHugePages), WithMemoryOverhead(vmi.Spec.Domain.Resources, memoryOverhead)),
 			NewVMIResourceRule(func(_ *v1.VirtualMachineInstance) bool {
-				return memoryLimitsOverhead.Value() > 0
+				return memoryLimitsOverhead.Value() > 0 && isMigrationTarget
 			}, WithMemoryLimitsOverhead(memoryLimitsOverhead)),
 			NewVMIResourceRule(t.doesVMIRequireAutoMemoryLimits, WithAutoMemoryLimits(vmi.Namespace, t.namespaceStore)),
 			NewVMIResourceRule(func(*v1.VirtualMachineInstance) bool {

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1374,6 +1374,31 @@ func addProbeOverheads(vmi *v1.VirtualMachineInstance, quantity *resource.Quanti
 	}
 }
 
+func addHotplugDisksOverheads(vmi *v1.VirtualMachineInstance, quantity *resource.Quantity) {
+	// We need to add this overhead due to potential OOMKill during
+	// migration with hotplugged disks.
+	hasHotplugs := false
+	for _, volume := range vmi.Spec.Volumes {
+		if volume.PersistentVolumeClaim != nil && volume.PersistentVolumeClaim.Hotpluggable {
+			hasHotplugs = true
+			break
+		}
+		if volume.ContainerDisk != nil && volume.ContainerDisk.Hotpluggable {
+			hasHotplugs = true
+			break
+		}
+		if volume.DataVolume != nil && volume.DataVolume.Hotpluggable {
+			hasHotplugs = true
+			break
+		}
+	}
+
+	if hasHotplugs {
+		hotplugOverhead := resource.MustParse("60Mi")
+		quantity.Add(hotplugOverhead)
+	}
+}
+
 func HaveContainerDiskVolume(volumes []v1.Volume) bool {
 	for _, volume := range volumes {
 		if volume.ContainerDisk != nil {

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1374,30 +1374,9 @@ func addProbeOverheads(vmi *v1.VirtualMachineInstance, quantity *resource.Quanti
 	}
 }
 
-// addHotplugDisksOverheads returns additional memory requests and limits needed to
-// overcome potential OOMKill during VM migration with hotplugged disks .
-func addHotplugDisksOverheads(vmi *v1.VirtualMachineInstance, overallOverhead *resource.Quantity, limitOnlyOverhead *resource.Quantity) {
-	hasHotplugDisks := false
-	for _, volume := range vmi.Spec.Volumes {
-		if volume.PersistentVolumeClaim != nil && volume.PersistentVolumeClaim.Hotpluggable {
-			hasHotplugDisks = true
-			break
-		}
-		if volume.ContainerDisk != nil && volume.ContainerDisk.Hotpluggable {
-			hasHotplugDisks = true
-			break
-		}
-		if volume.DataVolume != nil && volume.DataVolume.Hotpluggable {
-			hasHotplugDisks = true
-			break
-		}
-	}
-
-	// No disks, no changes.
-	if !hasHotplugDisks {
-		return
-	}
-
+// addDisksOverheads returns additional memory requests and limits needed to
+// overcome potential OOMKill during VM migration.
+func addDisksOverheads(vmi *v1.VirtualMachineInstance, overallOverhead *resource.Quantity, limitOnlyOverhead *resource.Quantity) {
 	overheadValue := resource.MustParse("60Mi")
 
 	reqCPU := vmi.Spec.Domain.Resources.Requests.Cpu()

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -393,14 +393,11 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 		})
 	}
 
-	// ImageIDs are passed when render target launch manifest for migration.
-	isMigrationTarget := imageIDs != nil
-
 	networkToResourceMap, err := multus.NetworkToResource(t.virtClient, vmi)
 	if err != nil {
 		return nil, err
 	}
-	resourceRenderer, err := t.newResourceRenderer(vmi, networkToResourceMap, isMigrationTarget)
+	resourceRenderer, err := t.newResourceRenderer(vmi, networkToResourceMap)
 	if err != nil {
 		return nil, err
 	}
@@ -909,7 +906,7 @@ func (t *templateService) newVolumeRenderer(vmi *v1.VirtualMachineInstance, name
 	return volumeRenderer, nil
 }
 
-func (t *templateService) newResourceRenderer(vmi *v1.VirtualMachineInstance, networkToResourceMap map[string]string, isMigrationTarget bool) (*ResourceRenderer, error) {
+func (t *templateService) newResourceRenderer(vmi *v1.VirtualMachineInstance, networkToResourceMap map[string]string) (*ResourceRenderer, error) {
 	vmiResources := vmi.Spec.Domain.Resources
 	baseOptions := []ResourceRendererOption{
 		WithEphemeralStorageRequest(),
@@ -920,7 +917,7 @@ func (t *templateService) newResourceRenderer(vmi *v1.VirtualMachineInstance, ne
 		return nil, err
 	}
 
-	options := append(baseOptions, t.VMIResourcePredicates(vmi, networkToResourceMap, isMigrationTarget).Apply()...)
+	options := append(baseOptions, t.VMIResourcePredicates(vmi, networkToResourceMap).Apply()...)
 	return NewResourceRenderer(vmiResources.Limits, vmiResources.Requests, options...), nil
 }
 
@@ -1666,7 +1663,7 @@ func (t *templateService) doesVMIRequireAutoCPULimits(vmi *v1.VirtualMachineInst
 	return false
 }
 
-func (t *templateService) VMIResourcePredicates(vmi *v1.VirtualMachineInstance, networkToResourceMap map[string]string, isMigrationTarget bool) VMIResourcePredicates {
+func (t *templateService) VMIResourcePredicates(vmi *v1.VirtualMachineInstance, networkToResourceMap map[string]string) VMIResourcePredicates {
 	// Set default with vmi Architecture. compatible with multi-architecture hybrid environments
 	vmiCPUArch := vmi.Spec.Architecture
 	if vmiCPUArch == "" {
@@ -1702,7 +1699,7 @@ func (t *templateService) VMIResourcePredicates(vmi *v1.VirtualMachineInstance, 
 			NewVMIResourceRule(hasHugePages, WithHugePages(vmi.Spec.Domain.Memory, memoryOverhead)),
 			NewVMIResourceRule(not(hasHugePages), WithMemoryOverhead(vmi.Spec.Domain.Resources, memoryOverhead)),
 			NewVMIResourceRule(func(_ *v1.VirtualMachineInstance) bool {
-				return memoryLimitsOverhead.Value() > 0 && isMigrationTarget
+				return memoryLimitsOverhead.Value() > 0
 			}, WithMemoryLimitsOverhead(memoryLimitsOverhead)),
 			NewVMIResourceRule(t.doesVMIRequireAutoMemoryLimits, WithAutoMemoryLimits(vmi.Namespace, t.namespaceStore)),
 			NewVMIResourceRule(func(*v1.VirtualMachineInstance) bool {

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1978,8 +1978,8 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal(requestMemory))
 				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal(limitMemory))
 			},
-				Entry("on amd64", "amd64", "1282971493", "2282971493"),
-				Entry("on arm64", "arm64", "1417189221", "2417189221"),
+				Entry("on amd64", "amd64", "1282971493", "2345886053"),
+				Entry("on arm64", "arm64", "1417189221", "2480103781"),
 			)
 			DescribeTable("should overcommit guest overhead if selected, by only adding the overhead to memory limits", func(arch string, limitMemory string) {
 				config, kvStore, svc = configFactory(arch)
@@ -2015,8 +2015,8 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal("1G"))
 				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal(limitMemory))
 			},
-				Entry("on amd64", "amd64", "2282971493"),
-				Entry("on arm64", "arm64", "2417189221"),
+				Entry("on amd64", "amd64", "2345886053"),
+				Entry("on arm64", "arm64", "2480103781"),
 			)
 			DescribeTable("should not add unset resources", func(arch string, requestMemory int) {
 				config, kvStore, svc = configFactory(arch)
@@ -2357,10 +2357,10 @@ var _ = Describe("Template", func() {
 						},
 					))
 			},
-				Entry("hugepages-2Mi on amd64", "amd64", "2Mi", 282),
-				Entry("hugepages-1Gi on amd64", "amd64", "1Gi", 282),
-				Entry("hugepages-2Mi on arm64", "arm64", "2Mi", 416),
-				Entry("hugepages-1Gi on arm64", "arm64", "1Gi", 416),
+				Entry("hugepages-2Mi on amd64", "amd64", "2Mi", 345),
+				Entry("hugepages-1Gi on amd64", "amd64", "1Gi", 345),
+				Entry("hugepages-2Mi on arm64", "arm64", "2Mi", 479),
+				Entry("hugepages-1Gi on arm64", "arm64", "1Gi", 479),
 			)
 			DescribeTable("should account for difference between guest and container requested memory ", func(arch string, memorySize int) {
 				config, kvStore, svc = configFactory(arch)
@@ -2436,8 +2436,8 @@ var _ = Describe("Template", func() {
 						},
 					))
 			},
-				Entry("on amd64", "amd64", 282),
-				Entry("on arm64", "arm64", 416),
+				Entry("on amd64", "amd64", 351),
+				Entry("on arm64", "arm64", 485),
 			)
 		})
 

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1978,8 +1978,8 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal(requestMemory))
 				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal(limitMemory))
 			},
-				Entry("on amd64", "amd64", "1282971493", "2345886053"),
-				Entry("on arm64", "arm64", "1417189221", "2480103781"),
+				Entry("on amd64", "amd64", "1282971493", "2282971493"),
+				Entry("on arm64", "arm64", "1417189221", "2417189221"),
 			)
 			DescribeTable("should overcommit guest overhead if selected, by only adding the overhead to memory limits", func(arch string, limitMemory string) {
 				config, kvStore, svc = configFactory(arch)
@@ -2054,8 +2054,8 @@ var _ = Describe("Template", func() {
 				// Limits for KVM and TUN devices should be requested.
 				Expect(pod.Spec.Containers[0].Resources.Limits).ToNot(BeNil())
 			},
-				Entry("on amd64", "amd64", 346),
-				Entry("on arm64", "arm64", 480),
+				Entry("on amd64", "amd64", 362),
+				Entry("on arm64", "arm64", 497),
 			)
 
 			DescribeTable("should check autoattachGraphicsDevicse", func(arch string, autoAttach *bool, memory int) {

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -2436,8 +2436,8 @@ var _ = Describe("Template", func() {
 						},
 					))
 			},
-				Entry("on amd64", "amd64", 351),
-				Entry("on arm64", "arm64", 485),
+				Entry("on amd64", "amd64", 357),
+				Entry("on arm64", "arm64", 491),
 			)
 		})
 

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -2015,8 +2015,8 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal("1G"))
 				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal(limitMemory))
 			},
-				Entry("on amd64", "amd64", "2345886053"),
-				Entry("on arm64", "arm64", "2480103781"),
+				Entry("on amd64", "amd64", "2282971493"),
+				Entry("on arm64", "arm64", "2417189221"),
 			)
 			DescribeTable("should not add unset resources", func(arch string, requestMemory int) {
 				config, kvStore, svc = configFactory(arch)
@@ -2054,8 +2054,8 @@ var _ = Describe("Template", func() {
 				// Limits for KVM and TUN devices should be requested.
 				Expect(pod.Spec.Containers[0].Resources.Limits).ToNot(BeNil())
 			},
-				Entry("on amd64", "amd64", 362),
-				Entry("on arm64", "arm64", 497),
+				Entry("on amd64", "amd64", 346),
+				Entry("on arm64", "arm64", 480),
 			)
 
 			DescribeTable("should check autoattachGraphicsDevicse", func(arch string, autoAttach *bool, memory int) {
@@ -2357,10 +2357,10 @@ var _ = Describe("Template", func() {
 						},
 					))
 			},
-				Entry("hugepages-2Mi on amd64", "amd64", "2Mi", 345),
-				Entry("hugepages-1Gi on amd64", "amd64", "1Gi", 345),
-				Entry("hugepages-2Mi on arm64", "arm64", "2Mi", 479),
-				Entry("hugepages-1Gi on arm64", "arm64", "1Gi", 479),
+				Entry("hugepages-2Mi on amd64", "amd64", "2Mi", 282),
+				Entry("hugepages-1Gi on amd64", "amd64", "1Gi", 282),
+				Entry("hugepages-2Mi on arm64", "arm64", "2Mi", 416),
+				Entry("hugepages-1Gi on arm64", "arm64", "1Gi", 416),
 			)
 			DescribeTable("should account for difference between guest and container requested memory ", func(arch string, memorySize int) {
 				config, kvStore, svc = configFactory(arch)
@@ -2436,8 +2436,8 @@ var _ = Describe("Template", func() {
 						},
 					))
 			},
-				Entry("on amd64", "amd64", 357),
-				Entry("on arm64", "arm64", 491),
+				Entry("on amd64", "amd64", 282),
+				Entry("on arm64", "arm64", 416),
 			)
 		})
 


### PR DESCRIPTION
## What this PR does

Add 60Mi more memory to the target Pod resource requirements depending on coreFraction value:

- Increase requests and limits if cpu cores are guaranteed (coreFraction = 100%)
- Increase limits only if cpu cores are not guaranteed (coreFraction < 100%).

This additional memory should prevent OOMKills for target Pod during migration with hotplugged disks.


## Result

### Pod resources for VM with 256Mi, 1 cpu, and 100% coreFraction (guaranteed)

**Before**:

```yaml
    resources:
      limits:
        cpu: "1"
        memory: "549978113"
      requests:
        cpu: "1"
        memory: "549978113"
```

**After**:

```yaml
    resources:
      limits:
        cpu: "1"
        memory: "612892673"
      requests:
        cpu: "1"
        memory: "612892673"       
```


### Pod resources for VM with 256Mi, 1 cpu, and 5% coreFraction (non-guaranteed)

**Before**:

```yaml
    resources:
      limits:
        cpu: "1"
        memory: "549978113"
      requests:
        cpu: 50m
        memory: "549978113"
```

**After**:

```yaml
    resources:
      limits:
        cpu: "1"
        memory: "612892673"
      requests:
        cpu: 50m
        memory: "549978113"       
```

