### PR TITLE
fix several issues related to qcow2-based storage migration

### DIFF
--- a/pkg/host-disk/creator.go
+++ b/pkg/host-disk/creator.go
@@ -5,8 +5,10 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/client-go/tools/record"
+
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+	kutil "kubevirt.io/kubevirt/pkg/util"
 
 	ephemeraldiskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 )
@@ -57,6 +59,7 @@ func (c diskImgCreator) handleRequestedSizeAndCreateQcow2(vmi *v1.VirtualMachine
 			return err
 		}
 	}
+	requestedSize = kutil.AlignImageSizeTo1MiB(requestedSize, log.Log.With("image", diskPath))
 	err = createQcow2(diskPath, requestedSize)
 	if err != nil {
 		log.Log.Reason(err).Errorf("Couldn't create a qcow2 file for disk path: %s, error: %v", diskPath, err)

--- a/pkg/host-disk/host-disk.go
+++ b/pkg/host-disk/host-disk.go
@@ -122,6 +122,25 @@ func replaceForHostDisk(volumeSource *v1.VolumeSource, volumeName string, pvcVol
 	if size == 0 {
 		return fmt.Errorf("the size for volume %s is too low, must be at least 1MiB", volumeName)
 	}
+
+	// If PVC filesystem overhead information is available, prefer the actual
+	// virtual size of the existing source image when creating the target qcow2.
+	//
+	// QEMU requires source and target images used for block migration to have
+	// exactly the same virtual size. Creating a target image based solely on the
+	// requested volume size may result in a size mismatch and cause migration
+	// failures such as:
+	//
+	//   "Source and target image have different sizes"
+	//
+	// Align the source image size to 1 MiB and use it for target image creation
+	// to satisfy QEMU strict size checks.
+	if volumeStatus.PersistentVolumeClaimInfo != nil && volumeStatus.PersistentVolumeClaimInfo.FilesystemOverhead != nil {
+		if volumeStatus.Size > 0 && volumeStatus.Size < size {
+			size = util.AlignImageSizeTo1MiB(volumeStatus.Size, log.Log)
+		}
+	}
+
 	capacity.Set(size)
 	volumeSource.HostDisk = &v1.HostDisk{
 		Path:     file,

--- a/pkg/host-disk/host-disk.go
+++ b/pkg/host-disk/host-disk.go
@@ -123,7 +123,7 @@ func replaceForHostDisk(volumeSource *v1.VolumeSource, volumeName string, pvcVol
 		return fmt.Errorf("the size for volume %s is too low, must be at least 1MiB", volumeName)
 	}
 
-	// If PVC filesystem overhead information is available, prefer the actual
+	// If it’s a PVC filesystem (we infer this indirectly by the presence of FilesystemOverhead), then prefer the actual
 	// virtual size of the existing source image when creating the target qcow2.
 	//
 	// QEMU requires source and target images used for block migration to have

--- a/pkg/os/disk/disk.go
+++ b/pkg/os/disk/disk.go
@@ -20,7 +20,9 @@ const (
 
 func GetDiskInfo(imagePath string) (*DiskInfo, error) {
 	// #nosec No risk for attacker injection. Only get information about an image
-	args := []string{"info", imagePath, "--output", "json"}
+	// Use -U (--force-share) to allow reading image metadata while the qcow2
+	// image is in use by a running VM, avoiding exclusive locks during probing.
+	args := []string{"info", "-U", imagePath, "--output", "json"}
 	cmd := exec.Command(QEMUIMGPath, args...)
 	stderr, err := cmd.StderrPipe()
 	if err != nil {

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -1044,9 +1044,11 @@ func configureLocalDiskToMigrate(dom *libvirtxml.Domain, vmi *v1.VirtualMachineI
 		if err != nil {
 			return err
 		}
+
 		// Configure the slice to enable to migrate the volume to a destination with different size
 		// See suggestion in: https://issues.redhat.com/browse/RHEL-4607
-		if dom.Devices.Disks[i].Source.Slices == nil {
+		// Skip Slices configuration for qcow2 disks
+		if dom.Devices.Disks[i].Driver.Type != "qcow2" && dom.Devices.Disks[i].Source.Slices == nil {
 			dom.Devices.Disks[i].Source.Slices = &libvirtxml.DomainDiskSlices{
 				Slices: []libvirtxml.DomainDiskSlice{
 					{


### PR DESCRIPTION
### What this PR does

This PR fixes several issues related to qcow2-based storage migration.

### Changes

1. **Use `qemu-img info -U` when probing qcow2 images**

   `qemu-img info` is now invoked with the `--force-share (-U)` option.  
   This allows reading qcow2 metadata while the image is attached to a running VM, avoiding image locking issues during metadata access.

2. **Create the target qcow2 image with the exact same virtual size as the source**

   The target qcow2 image is created using the virtual size of the existing source image.  
   This prevents migration failures caused by QEMU strict size checks, such as:
```
Source and target image have different sizes
```

3. **Ignore `DomainDiskSlice` for qcow2 disks**

`DomainDiskSlice` is now ignored for qcow2-based disks.

Storage slices are primarily intended to support migration to larger *raw* block devices.  
For qcow2 images this is unnecessary, since the target image is created with the exact same virtual size as the source.

Keeping slices enabled for qcow2 disks can lead to migration failures such as:

```
operation failed: migration of disk sda failed: No space left on device
```
even when the target image size is correctly MiB-aligned.
