### PR TITLE
fix: rename kubevirt.io:migrate clusterrole

### DIFF
--- a/pkg/virt-operator/resource/generate/rbac/cluster.go
+++ b/pkg/virt-operator/resource/generate/rbac/cluster.go
@@ -597,9 +597,10 @@ func newMigrateClusterRole() *rbacv1.ClusterRole {
 			Kind:       "ClusterRole",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "kubevirt.io:migrate",
+			Name: "kubevirt.internal.virtualization.deckhouse.io:migrate",
 			Labels: map[string]string{
 				virtv1.AppLabel: "",
+				"rbac.authorization.k8s.io/aggregate-to-edit": "true",
 			},
 		},
 		Rules: []rbacv1.PolicyRule{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

kubevirt.io:migrate ClusterRole blocks original KubeVirt installation: virt-operator stuck during deploy.

#### Before this PR:

```
kubevirt.internal.virtualization.deckhouse.io:admin
kubevirt.internal.virtualization.deckhouse.io:default
kubevirt.internal.virtualization.deckhouse.io:edit
kubevirt.internal.virtualization.deckhouse.io:view
kubevirt.io:migrate
```

#### After this PR:

```
kubevirt.internal.virtualization.deckhouse.io:admin
kubevirt.internal.virtualization.deckhouse.io:default
kubevirt.internal.virtualization.deckhouse.io:edit
kubevirt.internal.virtualization.deckhouse.io:view
kubevirt.internal.virtualization.deckhouse.io:migrate
```
