### PR TITLE
fix(hp): attachment pod creation during usb host device migration

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -644,6 +644,22 @@ func GetHotplugVolumes(vmi *v1.VirtualMachineInstance, virtlauncherPod *k8sv1.Po
 	return hotplugVolumes
 }
 
+func VMIHasHotplugResourceClaims(vmi *v1.VirtualMachineInstance) bool {
+	if vmi.Status.DeviceStatus != nil {
+		for _, deviceStatus := range vmi.Status.DeviceStatus.HostDeviceStatuses {
+			if deviceStatus.Hotplug != nil {
+				return true
+			}
+		}
+	}
+	for _, resourceClaim := range vmi.Spec.ResourceClaims {
+		if resourceClaim.Hotpluggable {
+			return true
+		}
+	}
+	return false
+}
+
 func GetHotplugResourceClaims(vmi *v1.VirtualMachineInstance) []*v1.ResourceClaim {
 	var hotplugResourceClaims []*v1.ResourceClaim
 	for _, resourceClaim := range vmi.Spec.ResourceClaims {

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1026,19 +1026,30 @@ func (t *templateService) RenderMigrationHotplugAttachmentPodTemplate(volumes []
 	// delete non-migratable resource claims
 	deleteCandidates := make(map[string]struct{})
 	for _, deviceStatus := range vmi.Status.DeviceStatus.HostDeviceStatuses {
-		if deviceStatus.DeviceResourceClaimStatus != nil && (!deviceStatus.DeviceResourceClaimStatus.AllowMultipleAllocations || deviceStatus.DeviceResourceClaimStatus.BindsToNode) {
+		// skip non-usb devices
+		if deviceStatus.DeviceResourceClaimStatus == nil || deviceStatus.DeviceResourceClaimStatus.Attributes == nil || deviceStatus.DeviceResourceClaimStatus.Attributes.USBAddress == nil {
+			continue
+		}
+
+		if !deviceStatus.DeviceResourceClaimStatus.AllowMultipleAllocations || deviceStatus.DeviceResourceClaimStatus.BindsToNode {
 			deleteCandidates[deviceStatus.Name] = struct{}{}
 		}
 	}
 
-	pod.Spec.ResourceClaims = slices.DeleteFunc(pod.Spec.ResourceClaims, func(rc k8sv1.PodResourceClaim) bool {
-		_, ok := deleteCandidates[rc.Name]
-		return ok
-	})
-	pod.Spec.Resources.Claims = slices.DeleteFunc(pod.Spec.Resources.Claims, func(rc k8sv1.ResourceClaim) bool {
-		_, ok := deleteCandidates[rc.Name]
-		return ok
-	})
+	if len(deleteCandidates) == 0 {
+		return pod, nil
+	}
+
+	if len(pod.Spec.ResourceClaims) > 0 {
+		pod.Spec.ResourceClaims = slices.DeleteFunc(pod.Spec.ResourceClaims, func(rc k8sv1.PodResourceClaim) bool {
+			_, ok := deleteCandidates[rc.Name]
+			return ok
+		})
+		pod.Spec.Containers[0].Resources.Claims = slices.DeleteFunc(pod.Spec.Containers[0].Resources.Claims, func(rc k8sv1.ResourceClaim) bool {
+			_, ok := deleteCandidates[rc.Name]
+			return ok
+		})
+	}
 
 	return pod, nil
 }

--- a/pkg/virt-controller/watch/migration/migration.go
+++ b/pkg/virt-controller/watch/migration/migration.go
@@ -1612,7 +1612,7 @@ func (c *Controller) sync(key string, migration *virtv1.VirtualMachineInstanceMi
 			}
 			return c.handleTargetPodCreation(key, migration, vmi, sourcePod)
 		} else if controller.IsPodReady(pod) {
-			if controller.VMIHasHotplugVolumes(vmi) {
+			if needMigrationHotplug(vmi) {
 				attachmentPods, err := controller.AttachmentPods(pod, c.podIndexer)
 				if err != nil {
 					return fmt.Errorf(failedGetAttractionPodsFmt, err)
@@ -2453,4 +2453,36 @@ func setMigrationFailedConditionIfNotExists(migration *virtv1.VirtualMachineInst
 			})
 		}
 	}
+}
+
+func needMigrationHotplug(vmi *virtv1.VirtualMachineInstance) bool {
+	if controller.VMIHasHotplugVolumes(vmi) {
+		return true
+	}
+
+	strategy := virtv1.GetUSBMigrationStrategy(vmi)
+	if strategy == virtv1.USBMigrationStrategyPrevent {
+		return controller.VMIHasHotplugResourceClaims(vmi)
+	}
+
+	hotplugClaims := controller.GetHotplugResourceClaims(vmi)
+	hotplugClaimNames := make(map[string]struct{})
+	for _, claim := range hotplugClaims {
+		hotplugClaimNames[claim.Name] = struct{}{}
+	}
+
+	if vmi.Status.DeviceStatus != nil {
+		for _, deviceStatus := range vmi.Status.DeviceStatus.HostDeviceStatuses {
+			// skip non-usb devices
+			if deviceStatus.DeviceResourceClaimStatus == nil || deviceStatus.DeviceResourceClaimStatus.Attributes == nil || deviceStatus.DeviceResourceClaimStatus.Attributes.USBAddress == nil {
+				continue
+			}
+
+			if !deviceStatus.DeviceResourceClaimStatus.AllowMultipleAllocations || deviceStatus.DeviceResourceClaimStatus.BindsToNode {
+				delete(hotplugClaimNames, deviceStatus.Name)
+			}
+		}
+	}
+
+	return len(hotplugClaimNames) > 0
 }


### PR DESCRIPTION
## Description

Two fixes for hotplug attachment pod creation during USB host device migration:

1. **`RenderMigrationHotplugAttachmentPodTemplate`**: filter only USB devices when building delete-candidates for non-migratable resource claims; guard against empty candidates to avoid unnecessary processing; fix resource claims cleanup to use `pod.Spec.Containers[0].Resources.Claims` instead of `pod.Spec.Resources.Claims`
2. **`needMigrationHotplug`**: new helper that determines whether a migration hotplug attachment pod is needed — combines existing hotplug volume check with hotplug resource claims check (respecting USB migration strategy); replaces the previous `VMIHasHotplugVolumes`-only check in the migration sync loop; adds `VMIHasHotplugResourceClaims` helper to `pkg/controller`

## Why do we need it, and what problem does it solve?

- Non-migratable resource claims were incorrectly deleted for non-USB host devices
- Migration hotplug pod was not triggered when a VMI had hotplug USB resource claims but no hotplug volumes
- Resource claims were cleaned up from the wrong field (`pod.Spec.Resources` instead of container-level resources)

## What is the expected result?

1. VMI with hotplug USB device and `Detach`/`Ignore` strategy: migration attachment pod is created correctly with non-migratable USB claims removed
2. VMI with hotplug USB device and `Prevent` strategy: migration attachment pod is created (device re-attach after migration)
3. Non-USB host devices are not affected by claim filtering
