### PR TITLE
feat: new cpu hotplug strategy: dynamic cores

### DIFF
--- a/pkg/safepath/safepath.go
+++ b/pkg/safepath/safepath.go
@@ -222,12 +222,12 @@ func GetxattrNoFollow(path *Path, attr string) ([]byte, error) {
 		return nil, err
 	}
 	defer pathFd.Close()
-	size, err := syscall.Getxattr(pathFd.SafePath(), attr, ret)
+	size, err := getxattr(pathFd.SafePath(), attr, ret)
 	if err != nil {
 		return nil, err
 	}
 	ret = make([]byte, size)
-	_, err = syscall.Getxattr(pathFd.SafePath(), attr, ret)
+	_, err = getxattr(pathFd.SafePath(), attr, ret)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/safepath/safepath_linux.go
+++ b/pkg/safepath/safepath_linux.go
@@ -101,3 +101,7 @@ func open(path string) (fd int, err error) {
 func path(fd int) string {
 	return fmt.Sprintf("/proc/self/fd/%d", fd)
 }
+
+func getxattr(path string, attr string, ret []byte) (size int, err error) {
+	return syscall.Getxattr(path, attr, ret)
+}

--- a/pkg/virt-controller/services/renderresources.go
+++ b/pkg/virt-controller/services/renderresources.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
@@ -54,6 +55,14 @@ func NewVMIResourceRule(p resourcePredicate, option ResourceRendererOption) VMIR
 
 func doesVMIRequireDedicatedCPU(vmi *v1.VirtualMachineInstance) bool {
 	return vmi.IsCPUDedicated()
+}
+
+func withoutDedicatedCPU(vmi *v1.VirtualMachineInstance) bool {
+	return !doesVMIRequireDedicatedCPU(vmi) && !doesVMIRequireFractionCPU(vmi)
+}
+
+func doesVMIRequireFractionCPU(vmi *v1.VirtualMachineInstance) bool {
+	return vmi.IsCPUFractioned()
 }
 
 func NewResourceRenderer(vmLimits k8sv1.ResourceList, vmRequests k8sv1.ResourceList, options ...ResourceRendererOption) *ResourceRenderer {
@@ -145,6 +154,56 @@ func WithoutDedicatedCPU(vmi *v1.VirtualMachineInstance, cpuAllocationRatio int,
 				renderer.calculatedLimits[k8sv1.ResourceCPU] = resource.MustParse(strconv.FormatInt(totalCPUs, 10))
 			}
 		}
+	}
+}
+
+// WithCPUFractionRequests sets cpu requests as a fraction percent of a total cpu count.
+func WithCPUFractionRequests(vmi *v1.VirtualMachineInstance, cpuFraction int) ResourceRendererOption {
+	return func(renderer *ResourceRenderer) {
+		cpu := vmi.Spec.Domain.CPU
+		vcpus := calcVCPUs(cpu)
+		ioThreadCPUs := getIOThreadsCount(vmi) // Get IO thread count
+		totalCPUs := vcpus + ioThreadCPUs      // Include IO threads
+		if totalCPUs != 0 {
+			requestsFraction := CalculateCPURequestsFraction(totalCPUs, cpuFraction)
+
+			renderer.calculatedRequests[k8sv1.ResourceCPU] = resource.MustParse(requestsFraction)
+			renderer.calculatedLimits[k8sv1.ResourceCPU] = *resource.NewQuantity(totalCPUs, resource.DecimalSI)
+		}
+	}
+}
+
+// CalculateCPURequestsFraction returns scaled totalCPUs in milli quantity if fraction is lower than 100.
+// Fraction is a percent of totalCPUs.
+// It returns totalCPUs number as a string if fraction is 100 or lower than 1.
+//
+// See GetScaledValueFromIntOrPercent from "k8s.io/apimachinery/pkg/util/intstr" package.
+func CalculateCPURequestsFraction(totalCPUs int64, cpuFraction int) string {
+	if cpuFraction <= 0 || cpuFraction > 100 {
+		cpuFraction = 100
+	}
+	if cpuFraction == 100 {
+		return fmt.Sprintf("%d", totalCPUs)
+	}
+
+	// Use multiplier to calculate fraction of millis.
+	total := totalCPUs * 1000
+	// Round up, to always return integer number of millis.
+	value := int64(math.Ceil(float64(cpuFraction) * (float64(total)) / 100))
+	return fmt.Sprintf("%dm", value)
+}
+
+// EnsureCPULimits sets CPU resources limits equal to requests with exception if
+// limits already set to greater value then requests.
+func EnsureCPULimits(vmi *v1.VirtualMachineInstance) ResourceRendererOption {
+	return func(renderer *ResourceRenderer) {
+		memoryRequest := renderer.vmRequests[k8sv1.ResourceCPU]
+		if memoryLimit, ok := renderer.vmLimits[k8sv1.ResourceCPU]; ok {
+			if memoryLimit.Cmp(memoryRequest) == 1 {
+				return
+			}
+		}
+		renderer.vmLimits[k8sv1.ResourceCPU] = renderer.vmRequests[k8sv1.ResourceCPU]
 	}
 }
 
@@ -640,6 +699,18 @@ func WithVirtualizationResources(virtResources k8sv1.ResourceList) ResourceRende
 	return func(renderer *ResourceRenderer) {
 		copyResources(virtResources, renderer.vmLimits)
 	}
+}
+
+func parseCPUFraction(vmi *v1.VirtualMachineInstance) (int, error) {
+	cpuFractionStr, hasAnnotation := vmi.Annotations[v1.CPUResourcesRequestsFraction]
+	if !hasAnnotation || cpuFractionStr == "" {
+		return 0, nil
+	}
+	intVal, err := strconv.Atoi(cpuFractionStr)
+	if err != nil {
+		return 0, fmt.Errorf("parse CPU fraction: %w", err)
+	}
+	return intVal, nil
 }
 
 func validatePermittedHostDevices(spec *v1.VirtualMachineInstanceSpec, config *virtconfig.ClusterConfig) error {

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -922,7 +922,12 @@ func (t *templateService) newResourceRenderer(vmi *v1.VirtualMachineInstance, ne
 		return nil, err
 	}
 
-	options := append(baseOptions, t.VMIResourcePredicates(vmi, networkToResourceMap).Apply()...)
+	cpuFraction, err := parseCPUFraction(vmi)
+	if err != nil {
+		return nil, err
+	}
+
+	options := append(baseOptions, t.VMIResourcePredicates(vmi, networkToResourceMap, cpuFraction).Apply()...)
 	return NewResourceRenderer(vmiResources.Limits, vmiResources.Requests, options...), nil
 }
 
@@ -1740,7 +1745,7 @@ func (t *templateService) doesVMIRequireAutoCPULimits(vmi *v1.VirtualMachineInst
 	return false
 }
 
-func (t *templateService) VMIResourcePredicates(vmi *v1.VirtualMachineInstance, networkToResourceMap map[string]string) VMIResourcePredicates {
+func (t *templateService) VMIResourcePredicates(vmi *v1.VirtualMachineInstance, networkToResourceMap map[string]string, cpuFraction int) VMIResourcePredicates {
 	// Set default with vmi Architecture. compatible with multi-architecture hybrid environments
 	vmiCPUArch := vmi.Spec.Architecture
 	if vmiCPUArch == "" {
@@ -1772,7 +1777,8 @@ func (t *templateService) VMIResourcePredicates(vmi *v1.VirtualMachineInstance, 
 				return t.clusterConfig.GetMemoryOvercommit() != 100
 			}, WithMemoryOvercommit(t.clusterConfig.GetMemoryOvercommit())),
 			NewVMIResourceRule(doesVMIRequireDedicatedCPU, WithCPUPinning(vmi, vmi.Annotations, additionalCPUs)),
-			NewVMIResourceRule(not(doesVMIRequireDedicatedCPU), WithoutDedicatedCPU(vmi, t.clusterConfig.GetCPUAllocationRatio(), withCPULimits)),
+			NewVMIResourceRule(withoutDedicatedCPU, WithoutDedicatedCPU(vmi, t.clusterConfig.GetCPUAllocationRatio(), withCPULimits)),
+			NewVMIResourceRule(doesVMIRequireFractionCPU, WithCPUFractionRequests(vmi, cpuFraction)),
 			NewVMIResourceRule(hasHugePages, WithHugePages(vmi.Spec.Domain.Memory, memoryOverhead)),
 			NewVMIResourceRule(not(hasHugePages), WithMemoryOverhead(vmi.Spec.Domain.Resources, memoryOverhead)),
 			NewVMIResourceRule(func(_ *v1.VirtualMachineInstance) bool {

--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -641,7 +641,9 @@ func (c *Controller) handleCPUChangeRequest(vm *virtv1.VirtualMachine, vmi *virt
 		return nil
 	}
 
-	if vmCopyWithInstancetype.Spec.Template.Spec.Domain.CPU.Sockets < vmi.Spec.Domain.CPU.Sockets {
+	// Allows CPU cores number reduction if "dynamic cores" strategy is enabled.
+	_, isDynamicCoresHotplug := vmCopyWithInstancetype.Annotations[virtv1.VCPUTopologyDynamicCoresAnnotation]
+	if !isDynamicCoresHotplug && vmCopyWithInstancetype.Spec.Template.Spec.Domain.CPU.Sockets < vmi.Spec.Domain.CPU.Sockets {
 		setRestartRequired(vm, "Reduction of CPU socket count requires a restart")
 		return nil
 	}

--- a/pkg/virt-launcher/virtwrap/converter/block_io.go
+++ b/pkg/virt-launcher/virtwrap/converter/block_io.go
@@ -1,0 +1,15 @@
+//go:build !linux
+
+package converter
+
+import (
+	"os"
+)
+
+func getBlockIOSizes(_ string, _ *os.File) (int, int, error) {
+	return 512, 4096, nil
+}
+
+const (
+	SYSCALL_O_DIRECT = 0
+)

--- a/pkg/virt-launcher/virtwrap/converter/block_io_linux.go
+++ b/pkg/virt-launcher/virtwrap/converter/block_io_linux.go
@@ -1,0 +1,28 @@
+//go:build linux
+
+package converter
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func getBlockIOSizes(path string, f *os.File) (int, int, error) {
+	logicalSize, err := unix.IoctlGetUint32(int(f.Fd()), unix.BLKSSZGET)
+	if err != nil {
+		return 0, 0, fmt.Errorf("unable to get logical block size from device %v: %v", path, err)
+	}
+	physicalSize, err := unix.IoctlGetUint32(int(f.Fd()), unix.BLKBSZGET)
+	if err != nil {
+		return 0, 0, fmt.Errorf("unable to get physical block size from device %v: %v", path, err)
+	}
+
+	return int(logicalSize), int(physicalSize), nil
+}
+
+const (
+	SYSCALL_O_DIRECT = syscall.O_DIRECT
+)

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -40,8 +40,6 @@ import (
 
 	hwutil "kubevirt.io/kubevirt/pkg/util/hardware"
 
-	"golang.org/x/sys/unix"
-
 	k8sv1 "k8s.io/api/core/v1"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -277,12 +275,12 @@ func (c *directIOChecker) CheckFile(path string) (bool, error) {
 // based on https://gitlab.com/qemu-project/qemu/-/blob/master/util/osdep.c#L344
 func (c *directIOChecker) check(path string, flags int) (bool, error) {
 	// #nosec No risk for path injection as we only open the file, not read from it. The function leaks only whether the directory to `path` exists.
-	f, err := os.OpenFile(path, flags|syscall.O_DIRECT, 0600)
+	f, err := os.OpenFile(path, flags|SYSCALL_O_DIRECT, 0600)
 	if err != nil {
 		// EINVAL is returned if the filesystem does not support the O_DIRECT flag
 		if err, ok := err.(*os.PathError); ok && err.Err == syscall.EINVAL {
 			// #nosec No risk for path injection as we only open the file, not read from it. The function leaks only whether the directory to `path` exists.
-			f, err := os.OpenFile(path, flags & ^syscall.O_DIRECT, 0600)
+			f, err := os.OpenFile(path, flags & ^SYSCALL_O_DIRECT, 0600)
 			if err == nil {
 				defer util.CloseIOAndCheckErr(f, nil)
 				return false, nil
@@ -331,13 +329,9 @@ func getOptimalBlockIOForDevice(path string) (*api.BlockIO, error) {
 	}
 	defer util.CloseIOAndCheckErr(f, nil)
 
-	logicalSize, err := unix.IoctlGetUint32(int(f.Fd()), unix.BLKSSZGET)
+	logicalSize, physicalSize, err := getBlockIOSizes(path, f)
 	if err != nil {
-		return nil, fmt.Errorf("unable to get logical block size from device %v: %v", path, err)
-	}
-	physicalSize, err := unix.IoctlGetUint32(int(f.Fd()), unix.BLKBSZGET)
-	if err != nil {
-		return nil, fmt.Errorf("unable to get physical block size from device %v: %v", path, err)
+		return nil, err
 	}
 
 	log.Log.Infof("Detected logical size of %d and physical size of %d for device %v", logicalSize, physicalSize, path)
@@ -1294,13 +1288,13 @@ func Convert_v1_Firmware_To_related_apis(vmi *v1.VirtualMachineInstance, domain 
 		log.Log.Object(vmi).Infof("kernel boot defined for VMI. Converting to domain XML")
 		if kb.Container.KernelPath != "" {
 			kernelPath := containerdisk.GetKernelBootArtifactPathFromLauncherView(kb.Container.KernelPath)
-			log.Log.Object(vmi).Infof("setting kernel path for kernel boot: " + kernelPath)
+			log.Log.Object(vmi).Infof("setting kernel path for kernel boot: %s", kernelPath)
 			domain.Spec.OS.Kernel = kernelPath
 		}
 
 		if kb.Container.InitrdPath != "" {
 			initrdPath := containerdisk.GetKernelBootArtifactPathFromLauncherView(kb.Container.InitrdPath)
-			log.Log.Object(vmi).Infof("setting initrd path for kernel boot: " + initrdPath)
+			log.Log.Object(vmi).Infof("setting initrd path for kernel boot: %s", initrdPath)
 			domain.Spec.OS.Initrd = initrdPath
 		}
 
@@ -1308,7 +1302,7 @@ func Convert_v1_Firmware_To_related_apis(vmi *v1.VirtualMachineInstance, domain 
 
 	// Define custom command-line arguments even if kernel-boot container is not defined
 	if firmware.KernelBoot != nil {
-		log.Log.Object(vmi).Infof("setting custom kernel arguments: " + firmware.KernelBoot.KernelArgs)
+		log.Log.Object(vmi).Infof("setting custom kernel arguments: %s", firmware.KernelBoot.KernelArgs)
 		domain.Spec.OS.KernelArgs = firmware.KernelBoot.KernelArgs
 	}
 
@@ -1525,14 +1519,20 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 	cpuTopology := vcpu.GetCPUTopology(vmi)
 	cpuCount := vcpu.CalculateRequestedVCPUs(cpuTopology)
 
-	domain.Spec.CPU.Topology = cpuTopology
-	domain.Spec.VCPU = &api.VCPU{
-		Placement: "static",
-		CPUs:      cpuCount,
-	}
 	// set the maximum number of sockets here to allow hot-plug CPUs
 	if vmiCPU := vmi.Spec.Domain.CPU; vmiCPU != nil && vmiCPU.MaxSockets != 0 && c.Architecture.SupportCPUHotplug() {
-		domainVCPUTopologyForHotplug(vmi, domain)
+		if _, ok := vmi.Annotations[v1.VCPUTopologyDynamicCoresAnnotation]; ok {
+			// "Dynamic cores" considers that user can change cores number instead of sockets.
+			domainVCPUTopologyForHotplugDynamicCores(vmi, domain)
+		} else {
+			domainVCPUTopologyForHotplug(vmi, domain)
+		}
+	} else {
+		domain.Spec.CPU.Topology = cpuTopology
+		domain.Spec.VCPU = &api.VCPU{
+			Placement: "static",
+			CPUs:      cpuCount,
+		}
 	}
 
 	kvmPath := "/dev/kvm"
@@ -2235,5 +2235,72 @@ func domainVCPUTopologyForHotplug(vmi *v1.VirtualMachineInstance, domain *api.Do
 	domain.Spec.VCPU = &api.VCPU{
 		Placement: "static",
 		CPUs:      cpuCount,
+	}
+}
+
+// domainVCPUTopologyForHotplugDynamicCores implements "dynamic cores" strategy for CPU hotplug.
+// This strategy considers that user can change cores number instead of sockets.
+// To accomplish this without huge refactoring we change vmi domain fields meaning:
+// 1) cores(-per-socket) field is used as a sockets number.
+// 2) sockets field is used as a dynamic cores-per-socket number.
+// 3) maxSockets field meaning is "max cores-per-socket".
+//
+// Also, sparse VCPUs array is used to distribute cores by sockets.
+// Example:
+// cores: 2, sockets: 9, maxSockets: 16
+// It becomes: 2 sockets, 9 cores per socket, max 16 cores per socket.
+// VCPUs array:
+// 0-15 - cores for socket 1
+// 16-31 - cores for socket 2.
+// For each socket first 9 cores are enabled, other 7 cores are disabled.
+// First 2 cores are non-hotpluggabled, others are hotpluggable.
+//
+// Note: It is not possible to have non-hotpluggable cores for each socket,
+// as QEMU expects non-hotpluggable VCPUs first and then hotpluggable VCPUs, so
+// we end up with simpler approach: make at least "sockets" count of VCPUs non-hotpluggable
+// for the first socket.
+func domainVCPUTopologyForHotplugDynamicCores(vmi *v1.VirtualMachineInstance, domain *api.Domain) {
+	// Convert "dynamic sockets" topology to "dynamic cores": swap cores and sockets.
+	cpuTopology := vcpu.GetCPUTopology(vmi)
+	coresPerSocket := cpuTopology.Sockets
+	sockets := cpuTopology.Cores
+	cpuTopology.Cores = coresPerSocket
+	cpuTopology.Sockets = sockets
+	enabledCoresTotal := vcpu.CalculateRequestedVCPUs(cpuTopology)
+
+	// Set cores to maximum limit to enable hotplug. (Max cores per socket value is passed as MaxSockets to bypass validation).
+	cpuTopology.Cores = vmi.Spec.Domain.CPU.MaxSockets
+	maxCoresTotal := vcpu.CalculateRequestedVCPUs(cpuTopology)
+
+	// At least 1 core per socket should be non-hotpluggable.
+	nonHotpluggableCores := sockets
+	// Count vCPUs per socket.
+	enabledCoresPerSocket := enabledCoresTotal / sockets
+	maxCoresPerSocket := maxCoresTotal / sockets
+
+	VCPUs := &api.VCPUs{}
+	for sockId := uint32(0); sockId < sockets; sockId++ {
+		for coreId := uint32(0); coreId < maxCoresPerSocket; coreId++ {
+			vcpuId := maxCoresPerSocket*sockId + coreId
+			// First nonHotpluggableCores vcpus in socket 0 will be non-hotpluggable.
+			isHotpluggable := vcpuId >= nonHotpluggableCores
+			// Enable requested number of vCPUs per socket.
+			isEnabled := coreId < enabledCoresPerSocket
+
+			vcpu := api.VCPUsVCPU{
+				ID:           vcpuId,
+				Enabled:      boolToYesNo(&isEnabled, true),
+				Hotpluggable: boolToYesNo(&isHotpluggable, false),
+				Order:        coreId*sockets + sockId + 1, // Order should be greater than 0.
+			}
+			VCPUs.VCPU = append(VCPUs.VCPU, vcpu)
+		}
+	}
+
+	domain.Spec.VCPUs = VCPUs
+	domain.Spec.CPU.Topology = cpuTopology
+	domain.Spec.VCPU = &api.VCPU{
+		Placement: "static",
+		CPUs:      maxCoresTotal,
 	}
 }

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -1037,6 +1037,111 @@ var _ = Describe("Converter", func() {
 				Entry("on s390x", s390x),
 			)
 
+			DescribeTable("should define hotplugable distributed topology", func(arch string) {
+				v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+				vmiCopy := vmi.DeepCopy()
+				// 2 sockets, max 4 cores per socket, 3 cores are enabled for each socket.
+				vmiCopy.Spec.Domain.CPU = &v1.CPU{
+					Cores:      2,
+					MaxSockets: 4,
+					Sockets:    3,
+				}
+				if vmiCopy.Annotations == nil {
+					vmiCopy.Annotations = map[string]string{}
+				}
+				vmiCopy.Annotations[v1.VCPUTopologyDynamicCoresAnnotation] = ""
+
+				c.Architecture = archconverter.NewConverter(arch)
+				domainSpec := vmiToDomainXMLToDomainSpec(vmiCopy, c)
+				Expect(domainSpec.CPU.Topology.Cores).To(Equal(uint32(4)), "Expect cores")
+				Expect(domainSpec.CPU.Topology.Sockets).To(Equal(uint32(2)), "Expect sockets")
+				Expect(domainSpec.CPU.Topology.Threads).To(Equal(uint32(1)), "Expect threads")
+				Expect(domainSpec.VCPU.CPUs).To(Equal(uint32(8)), "Expect vcpus")
+				Expect(domainSpec.VCPUs).ToNot(BeNil(), "Expecting topology for hotplug")
+				Expect(domainSpec.VCPUs.VCPU).To(HaveLen(8), "Expecting topology for hotplug")
+				Expect(domainSpec.VCPUs.VCPU[0].Hotpluggable).To(Equal("no"), "Expecting the 1st vcpu to be stable")
+				Expect(domainSpec.VCPUs.VCPU[1].Hotpluggable).To(Equal("no"), "Expecting the 2nd vcpu to be stable")
+				Expect(domainSpec.VCPUs.VCPU[2].Hotpluggable).To(Equal("yes"), "Expecting the 3rd vcpu to be Hotpluggable")
+				Expect(domainSpec.VCPUs.VCPU[3].Hotpluggable).To(Equal("yes"), "Expecting the 4th vcpu to be Hotpluggable")
+				Expect(domainSpec.VCPUs.VCPU[4].Hotpluggable).To(Equal("yes"), "Expecting the 5th vcpu to be Hotpluggable")
+				Expect(domainSpec.VCPUs.VCPU[5].Hotpluggable).To(Equal("yes"), "Expecting the 6th vcpu to be Hotpluggable")
+				Expect(domainSpec.VCPUs.VCPU[6].Hotpluggable).To(Equal("yes"), "Expecting the 7th vcpu to be Hotpluggable")
+				Expect(domainSpec.VCPUs.VCPU[7].Hotpluggable).To(Equal("yes"), "Expecting the 8th vcpu to be Hotpluggable")
+				Expect(domainSpec.VCPUs.VCPU[0].Enabled).To(Equal("yes"), "Expecting the 1st vcpu to be enabled")
+				Expect(domainSpec.VCPUs.VCPU[1].Enabled).To(Equal("yes"), "Expecting the 2nd vcpu to be enabled")
+				Expect(domainSpec.VCPUs.VCPU[2].Enabled).To(Equal("yes"), "Expecting the 3rd vcpu to be enabled")
+				Expect(domainSpec.VCPUs.VCPU[3].Enabled).To(Equal("no"), "Expecting the 4th vcpu to be disabled")
+				Expect(domainSpec.VCPUs.VCPU[4].Enabled).To(Equal("yes"), "Expecting the 5th vcpu to be enabled")
+				Expect(domainSpec.VCPUs.VCPU[5].Enabled).To(Equal("yes"), "Expecting the 6th vcpu to be enabled")
+				Expect(domainSpec.VCPUs.VCPU[6].Enabled).To(Equal("yes"), "Expecting the 7th vcpu to be enabled")
+				Expect(domainSpec.VCPUs.VCPU[7].Enabled).To(Equal("no"), "Expecting the 8th vcpu to be disabled")
+				Expect(domainSpec.VCPUs.VCPU[0].ID).To(BeEquivalentTo(0))
+				Expect(domainSpec.VCPUs.VCPU[1].ID).To(BeEquivalentTo(1))
+				Expect(domainSpec.VCPUs.VCPU[2].ID).To(BeEquivalentTo(2))
+				Expect(domainSpec.VCPUs.VCPU[3].ID).To(BeEquivalentTo(3))
+				Expect(domainSpec.VCPUs.VCPU[4].ID).To(BeEquivalentTo(4))
+				Expect(domainSpec.VCPUs.VCPU[5].ID).To(BeEquivalentTo(5))
+				Expect(domainSpec.VCPUs.VCPU[6].ID).To(BeEquivalentTo(6))
+				Expect(domainSpec.VCPUs.VCPU[7].ID).To(BeEquivalentTo(7))
+			},
+				Entry("on amd64", amd64),
+				Entry("on ppc64le", ppc64le),
+				Entry("on s390x", s390x),
+			)
+
+			DescribeTable("should define hotplugable distributed topology", func(arch string) {
+				v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+				vmiCopy := vmi.DeepCopy()
+				// 2 sockets, max 4 cores per socket, 3 cores are enabled for each socket.
+				vmiCopy.Spec.Domain.CPU = &v1.CPU{
+					Cores:      2,
+					MaxSockets: 16,
+					Sockets:    14,
+				}
+				if vmiCopy.Annotations == nil {
+					vmiCopy.Annotations = map[string]string{}
+				}
+				vmiCopy.Annotations[v1.VCPUTopologyDynamicCoresAnnotation] = ""
+
+				c.Architecture = archconverter.NewConverter(arch)
+				domainSpec := vmiToDomainXMLToDomainSpec(vmiCopy, c)
+				Expect(domainSpec.CPU.Topology.Cores).To(Equal(uint32(16)), "Expect cores")
+				Expect(domainSpec.CPU.Topology.Sockets).To(Equal(uint32(2)), "Expect sockets")
+				Expect(domainSpec.CPU.Topology.Threads).To(Equal(uint32(1)), "Expect threads")
+				Expect(domainSpec.VCPU.CPUs).To(Equal(uint32(16*2)), "Expect vcpus")
+				Expect(domainSpec.VCPUs).ToNot(BeNil(), "Expecting topology for hotplug")
+				Expect(domainSpec.VCPUs.VCPU).To(HaveLen(16*2), "Expecting topology for hotplug")
+				Expect(domainSpec.VCPUs.VCPU[0].Hotpluggable).To(Equal("no"), "Expecting the 1st vcpu to be stable")
+				Expect(domainSpec.VCPUs.VCPU[1].Hotpluggable).To(Equal("no"), "Expecting the 2nd vcpu to be stable")
+				Expect(domainSpec.VCPUs.VCPU[2].Hotpluggable).To(Equal("yes"), "Expecting the 3rd vcpu to be hotpluggable")
+				Expect(domainSpec.VCPUs.VCPU[15].Hotpluggable).To(Equal("yes"), "Expecting the 4th vcpu to be hotpluggable")
+				Expect(domainSpec.VCPUs.VCPU[16].Hotpluggable).To(Equal("yes"), "Expecting the 5th vcpu to be hotpluggable")
+				Expect(domainSpec.VCPUs.VCPU[17].Hotpluggable).To(Equal("yes"), "Expecting the 6th vcpu to be hotpluggable")
+				Expect(domainSpec.VCPUs.VCPU[30].Hotpluggable).To(Equal("yes"), "Expecting the 7th vcpu to be hotpluggable")
+				Expect(domainSpec.VCPUs.VCPU[31].Hotpluggable).To(Equal("yes"), "Expecting the 8th vcpu to be hotpluggable")
+				Expect(domainSpec.VCPUs.VCPU[0].Enabled).To(Equal("yes"), "Expecting the 1st vcpu to be enabled")
+				Expect(domainSpec.VCPUs.VCPU[1].Enabled).To(Equal("yes"), "Expecting the 2nd vcpu to be enabled")
+				Expect(domainSpec.VCPUs.VCPU[13].Enabled).To(Equal("yes"), "Expecting the 13th vcpu to be enabled")
+				Expect(domainSpec.VCPUs.VCPU[14].Enabled).To(Equal("no"), "Expecting the 14th vcpu to be disabled")
+				Expect(domainSpec.VCPUs.VCPU[15].Enabled).To(Equal("no"), "Expecting the 15th vcpu to be enabled")
+				Expect(domainSpec.VCPUs.VCPU[0+16].Enabled).To(Equal("yes"), "Expecting the 16th vcpu to be enabled")
+				Expect(domainSpec.VCPUs.VCPU[1+16].Enabled).To(Equal("yes"), "Expecting the 17th vcpu to be enabled")
+				Expect(domainSpec.VCPUs.VCPU[13+16].Enabled).To(Equal("yes"), "Expecting the 29th vcpu to be enabled")
+				Expect(domainSpec.VCPUs.VCPU[14+16].Enabled).To(Equal("no"), "Expecting the 30th vcpu to be disabled")
+				Expect(domainSpec.VCPUs.VCPU[15+16].Enabled).To(Equal("no"), "Expecting the 31th vcpu to be enabled")
+				Expect(domainSpec.VCPUs.VCPU[0].ID).To(BeEquivalentTo(0))
+				Expect(domainSpec.VCPUs.VCPU[1].ID).To(BeEquivalentTo(1))
+				Expect(domainSpec.VCPUs.VCPU[15].ID).To(BeEquivalentTo(15))
+				Expect(domainSpec.VCPUs.VCPU[16].ID).To(BeEquivalentTo(16))
+				Expect(domainSpec.VCPUs.VCPU[17].ID).To(BeEquivalentTo(17))
+				Expect(domainSpec.VCPUs.VCPU[30].ID).To(BeEquivalentTo(30))
+				Expect(domainSpec.VCPUs.VCPU[31].ID).To(BeEquivalentTo(31))
+			},
+				Entry("on amd64", amd64),
+				Entry("on ppc64le", ppc64le),
+				Entry("on s390x", s390x),
+			)
+
 			It("should not define hotplugable topology for ARM64", func() {
 				v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 				vmi.Spec.Architecture = arm64

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -637,6 +637,12 @@ func (v *VirtualMachineInstance) IsCPUDedicated() bool {
 	return v.Spec.Domain.CPU != nil && v.Spec.Domain.CPU.DedicatedCPUPlacement
 }
 
+// IsCPUFractioned checks if CPU fraction requests has been requested.
+func (v *VirtualMachineInstance) IsCPUFractioned() bool {
+	_, hasFraction := v.Annotations[CPUResourcesRequestsFraction]
+	return v.Spec.Domain.CPU != nil && hasFraction
+}
+
 func (v *VirtualMachineInstance) IsBootloaderEFI() bool {
 	return v.Spec.Domain.Firmware != nil && v.Spec.Domain.Firmware.Bootloader != nil &&
 		v.Spec.Domain.Firmware.Bootloader.EFI != nil
@@ -1480,6 +1486,13 @@ const (
 	// DisablePCIHole64 indicates that the 64-Bit PCI hole should be disabled on a VirtualMachineInstance.
 	// This annotation might be deprecated in the future if we decided to add a struct for it.
 	DisablePCIHole64 string = "kubevirt.io/disablePCIHole64"
+)
+
+const (
+	// VCPUTopologyDynamicCoresAnnotation annotation indicates "distributed by sockets" or "dynamic cores number" VCPU topology.
+	VCPUTopologyDynamicCoresAnnotation = "internal.virtualization.deckhouse.io/vcpu-topology-dynamic-cores"
+
+	CPUResourcesRequestsFraction = "internal.virtualization.deckhouse.io/cpu-resources-requests-fraction"
 )
 
 func NewVMI(name string, uid types.UID) *VirtualMachineInstance {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This PR implements a new strategy for CPU hotplugging: "dynamic cores number" instead of "dynamic sockets number" in original Kubevirt. Also, it moves some logic from virtualization-controller: cpu fraction calculation, adding cpu limits for main Pod and target Pod.

New annotations for KVVM are introduced:

- `internal.virtualization.deckhouse.io/vcpu-topology-dynamic-cores` - enable "dynamic cores" strategy for hotplug. If annotation is present, XML renderer interprets spec.domain.cpu.cores as sockets and sockets/maxSockets as cores. This swap is a workaround to bypass vm-validator webhook. This swap is also added to the is done in virtualization-controller.
- `internal.virtualization.deckhouse.io/cpu-resources-requests-fraction` - specify integer number of percents of a CPU fraction. This value is used to calculate resources.requests for Pods.

Notes:
1. Memory hotplug support is added for testing purposes (https://github.com/deckhouse/3p-kubevirt/pull/79)
2. `block_io` and `safepath` additions are minor changes only to support running unit tests in MacOS.

#### Before this PR:

Static cores-per-socket and dynamic sockets fields are used to specify hotplugged cores in resulted XML.

```
boot: VM with 2 cores

1 socket, 2 cores, 4 maxSockets

[o o] [- -] [- -] [- -]

hotplug: increase cpu to 6 cores: set sockets to 3

3 sockets, 2 cores, 4 maxSockets

[o o] [o o] [o o] [- -]
```

#### After this PR:

Dynamic cores-per-socket and static sockets are used to specify hotplugged cores in resulted XML.

```
boot: VM with 2 cores

1 socket, 2 cores, 4 maxSockets (equal to: 1 core per socket, 2 sockets, 4 cores per socket max)

[o - - -] [o - - -]

hotplug: increase cpu to 6 cores: set sockets to 3

3 sockets, 2 cores, 4 maxSockets (same as before, but different topology: 3 cores per socket, 2 sockets, 4 cores per socket max)

[o o o -] [o o o -]
```

Note: enabled cores are sparsed to fill sockets equally.

### References

TODO add link to performance considerations sockets vs cores.
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way

We need to hotplug cores in a "dynamic cores per socket" way.


