### PR TITLE
fix: protect hp pod with new d8 label

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter.go
@@ -185,7 +185,7 @@ func isVirtLauncher(pod *k8scorev1.Pod) bool {
 }
 
 func isHotplugPod(pod *k8scorev1.Pod) bool {
-	return pod.Labels[virtv1.AppLabel] == "hotplug-disk" && len(pod.OwnerReferences) == 1
+	return pod.Labels[virtv1.AppLabel] == "d8v-hotplug-disk" && len(pod.OwnerReferences) == 1
 }
 
 func isCompleted(pod *k8scorev1.Pod) bool {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter_test.go
@@ -534,7 +534,7 @@ func newHotplugPod(virtLauncherPod *k8sv1.Pod) *k8sv1.Pod {
 		},
 	})
 	hotplugPod.SetLabels(map[string]string{
-		virtv1.AppLabel: "hotplug-disk",
+		virtv1.AppLabel: "d8v-hotplug-disk",
 	})
 
 	return hotplugPod


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

